### PR TITLE
Feature/product domain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-logging'
+    implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'javax.validation:validation-api:2.0.1.Final'
 
     implementation "org.apache.avro:avro:1.11.0"

--- a/src/main/java/com/shoes/ordering/system/domains/common/exception/DTOException.java
+++ b/src/main/java/com/shoes/ordering/system/domains/common/exception/DTOException.java
@@ -1,0 +1,12 @@
+package com.shoes.ordering.system.domains.common.exception;
+
+public class DTOException extends RuntimeException {
+
+    public DTOException(String message) {
+        super(message);
+    }
+
+    public DTOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/common/validation/SelfValidating.java
+++ b/src/main/java/com/shoes/ordering/system/domains/common/validation/SelfValidating.java
@@ -1,0 +1,19 @@
+package com.shoes.ordering.system.domains.common.validation;
+
+import javax.validation.*;
+import java.util.Set;
+
+public abstract class SelfValidating<T> {
+
+    private final Validator validator;
+    public SelfValidating() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+    protected void validateSelf(T instance) {
+        Set<ConstraintViolation<T>> violations = validator.validate(instance);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceImpl.java
@@ -1,0 +1,48 @@
+package com.shoes.ordering.system.domains.product.domain.application;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.handler.CreateProductCommandHandler;
+import com.shoes.ordering.system.domains.product.domain.application.handler.TrackProductQueryHandler;
+import com.shoes.ordering.system.domains.product.domain.application.handler.UpdateProductCommandHandler;
+import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductApplicationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+@Slf4j
+@Validated
+@Service
+public class ProductApplicationServiceImpl implements ProductApplicationService {
+
+    private final CreateProductCommandHandler createProductCommandHandler;
+    private final UpdateProductCommandHandler updateProductCommandHandler;
+    private final TrackProductQueryHandler trackProductQueryHandler;
+
+    public ProductApplicationServiceImpl(CreateProductCommandHandler createProductCommandHandler,
+                                         UpdateProductCommandHandler updateProductCommandHandler,
+                                         TrackProductQueryHandler trackProductQueryHandler) {
+        this.createProductCommandHandler = createProductCommandHandler;
+        this.updateProductCommandHandler = updateProductCommandHandler;
+        this.trackProductQueryHandler = trackProductQueryHandler;
+    }
+
+    @Override
+    public CreateProductResponse createProduct(CreateProductCommand createProductCommand) {
+        return createProductCommandHandler.createProduct(createProductCommand);
+    }
+
+    @Override
+    public UpdateProductResponse updateProduct(UpdateProductCommand updateProductCommand) {
+        return null;
+    }
+
+    @Override
+    public TrackProductResponse trackProduct(TrackProductQuery trackProductQuery) {
+        return null;
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceImpl.java
@@ -38,7 +38,7 @@ public class ProductApplicationServiceImpl implements ProductApplicationService 
 
     @Override
     public UpdateProductResponse updateProduct(UpdateProductCommand updateProductCommand) {
-        return null;
+        return updateProductCommandHandler.updateProduct(updateProductCommand);
     }
 
     @Override

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceImpl.java
@@ -2,12 +2,9 @@ package com.shoes.ordering.system.domains.product.domain.application;
 
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.handler.CreateProductCommandHandler;
-import com.shoes.ordering.system.domains.product.domain.application.handler.TrackProductQueryHandler;
 import com.shoes.ordering.system.domains.product.domain.application.handler.UpdateProductCommandHandler;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductApplicationService;
 import lombok.extern.slf4j.Slf4j;
@@ -21,14 +18,10 @@ public class ProductApplicationServiceImpl implements ProductApplicationService 
 
     private final CreateProductCommandHandler createProductCommandHandler;
     private final UpdateProductCommandHandler updateProductCommandHandler;
-    private final TrackProductQueryHandler trackProductQueryHandler;
-
     public ProductApplicationServiceImpl(CreateProductCommandHandler createProductCommandHandler,
-                                         UpdateProductCommandHandler updateProductCommandHandler,
-                                         TrackProductQueryHandler trackProductQueryHandler) {
+                                         UpdateProductCommandHandler updateProductCommandHandler) {
         this.createProductCommandHandler = createProductCommandHandler;
         this.updateProductCommandHandler = updateProductCommandHandler;
-        this.trackProductQueryHandler = trackProductQueryHandler;
     }
 
     @Override
@@ -39,10 +32,5 @@ public class ProductApplicationServiceImpl implements ProductApplicationService 
     @Override
     public UpdateProductResponse updateProduct(UpdateProductCommand updateProductCommand) {
         return updateProductCommandHandler.updateProduct(updateProductCommand);
-    }
-
-    @Override
-    public TrackProductResponse trackProduct(TrackProductQuery trackProductQuery) {
-        return null;
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceImpl.java
@@ -1,0 +1,18 @@
+package com.shoes.ordering.system.domains.product.domain.application;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+@Slf4j
+@Validated
+@Service
+public class ProductQueryServiceImpl implements ProductQueryService {
+    @Override
+    public TrackProductResponse trackProduct(TrackProductQuery trackProductQuery) {
+        return null;
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceImpl.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-import java.util.List;
 
 @Slf4j
 @Validated
@@ -32,8 +31,8 @@ public class ProductQueryServiceImpl implements ProductQueryService {
         return trackProductQueryHandler.trackProduct(trackProductQuery);
     }
     @Override
-    public List<TrackProductListResponse> trackProductWithCategory(TrackProductListQuery trackProductListQuery) {
-        return null;
+    public TrackProductListResponse trackProductWithCategory(TrackProductListQuery trackProductListQuery) {
+        return trackProductListQueryHandler.trackProductWithCategory(trackProductListQuery);
     }
 
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceImpl.java
@@ -1,18 +1,39 @@
 package com.shoes.ordering.system.domains.product.domain.application;
 
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.handler.TrackProductListQueryHandler;
+import com.shoes.ordering.system.domains.product.domain.application.handler.TrackProductQueryHandler;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.List;
+
 @Slf4j
 @Validated
 @Service
 public class ProductQueryServiceImpl implements ProductQueryService {
+
+    private final TrackProductQueryHandler trackProductQueryHandler;
+    private final TrackProductListQueryHandler trackProductListQueryHandler;
+
+    public ProductQueryServiceImpl(TrackProductQueryHandler trackProductQueryHandler,
+                                   TrackProductListQueryHandler trackProductListQueryHandler) {
+        this.trackProductQueryHandler = trackProductQueryHandler;
+        this.trackProductListQueryHandler = trackProductListQueryHandler;
+    }
+
     @Override
     public TrackProductResponse trackProduct(TrackProductQuery trackProductQuery) {
+        return trackProductQueryHandler.trackProduct(trackProductQuery);
+    }
+    @Override
+    public List<TrackProductListResponse> trackProductWithCategory(TrackProductListQuery trackProductListQuery) {
         return null;
     }
+
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/ProductDTOException.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/ProductDTOException.java
@@ -1,0 +1,13 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto;
+
+import com.shoes.ordering.system.domains.common.exception.DTOException;
+
+public class ProductDTOException extends DTOException {
+    public ProductDTOException(String message) {
+        super(message);
+    }
+
+    public ProductDTOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductCommand.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductCommand.java
@@ -1,0 +1,73 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.create;
+
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+public class CreateProductCommand extends SelfValidating<CreateProductCommand> {
+
+    @NotNull private final String name;
+    @NotNull private final ProductCategory productCategory;
+    @NotNull private final String description;
+    @NotNull private final Money price;
+    private final @NotNull List<String> productImages;
+
+    private CreateProductCommand(Builder builder) {
+        name = builder.name;
+        productCategory = builder.productCategory;
+        description = builder.description;
+        price = builder.price;
+        productImages = builder.productImages;
+
+        this.validateSelf(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @NotNull String name;
+        private @NotNull ProductCategory productCategory;
+        private @NotNull String description;
+        private @NotNull Money price;
+        private @NotNull List<String> productImages;
+
+        private Builder() {
+        }
+
+        public Builder name(@NotNull String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder productCategory(@NotNull ProductCategory val) {
+            productCategory = val;
+            return this;
+        }
+
+        public Builder description(@NotNull String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder price(@NotNull Money val) {
+            price = val;
+            return this;
+        }
+
+        public Builder productImages(@NotNull List<String> val) {
+            productImages = val;
+            return this;
+        }
+
+        public CreateProductCommand build() {
+            return new CreateProductCommand(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductCommand.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductCommand.java
@@ -2,13 +2,15 @@ package com.shoes.ordering.system.domains.product.domain.application.dto.create;
 
 import com.shoes.ordering.system.domains.common.validation.SelfValidating;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
-import lombok.Getter;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
-@Getter
 public class CreateProductCommand extends SelfValidating<CreateProductCommand> {
 
     @NotNull private final String name;
@@ -25,6 +27,28 @@ public class CreateProductCommand extends SelfValidating<CreateProductCommand> {
         productImages = builder.productImages;
 
         this.validateSelf(this);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ProductCategory getProductCategory() {
+        return productCategory;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Money getPrice() {
+        return price;
+    }
+
+    public List<ProductImage> getProductImages() {
+        return productImages.stream()
+                .map(url -> new ProductImage(new ProductImageId(UUID.randomUUID()), url))
+                .collect(Collectors.toList());
     }
 
     public static Builder builder() {

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductResponse.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductResponse.java
@@ -1,0 +1,73 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.create;
+
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+public class CreateProductResponse extends SelfValidating<CreateProductResponse> {
+
+    @NotNull private final String name;
+    @NotNull private final ProductCategory productCategory;
+    @NotNull private final String description;
+    @NotNull private final Money price;
+    private final @NotNull List<String> productImages;
+
+    private CreateProductResponse(CreateProductResponse.Builder builder) {
+        name = builder.name;
+        productCategory = builder.productCategory;
+        description = builder.description;
+        price = builder.price;
+        productImages = builder.productImages;
+
+        this.validateSelf(this);
+    }
+
+    public static CreateProductResponse.Builder builder() {
+        return new CreateProductResponse.Builder();
+    }
+
+    public static final class Builder {
+        private @NotNull String name;
+        private @NotNull ProductCategory productCategory;
+        private @NotNull String description;
+        private @NotNull Money price;
+        private @NotNull List<String> productImages;
+
+        private Builder() {
+        }
+
+        public CreateProductResponse.Builder name(@NotNull String val) {
+            name = val;
+            return this;
+        }
+
+        public CreateProductResponse.Builder productCategory(@NotNull ProductCategory val) {
+            productCategory = val;
+            return this;
+        }
+
+        public CreateProductResponse.Builder description(@NotNull String val) {
+            description = val;
+            return this;
+        }
+
+        public CreateProductResponse.Builder price(@NotNull Money val) {
+            price = val;
+            return this;
+        }
+
+        public CreateProductResponse.Builder productImages(@NotNull List<String> val) {
+            productImages = val;
+            return this;
+        }
+
+        public CreateProductResponse build() {
+            return new CreateProductResponse(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListQuery.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListQuery.java
@@ -3,12 +3,14 @@ package com.shoes.ordering.system.domains.product.domain.application.dto.track;
 import com.shoes.ordering.system.domains.common.validation.SelfValidating;
 import com.shoes.ordering.system.domains.product.domain.application.dto.ProductDTOException;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+@Getter
 public class TrackProductListQuery extends SelfValidating<TrackProductListQuery> {
 
     @NotNull private final List<ProductCategory> productCategoryList;

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListQuery.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListQuery.java
@@ -1,0 +1,51 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.product.domain.application.dto.ProductDTOException;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+
+import javax.validation.constraints.NotNull;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class TrackProductListQuery extends SelfValidating<TrackProductListQuery> {
+
+    @NotNull private final List<ProductCategory> productCategoryList;
+
+    private TrackProductListQuery(Builder builder) {
+        productCategoryList = builder.productCategoryList;
+        this.validateSelf(this);
+        validateProductCategoryList();
+    }
+
+    private void validateProductCategoryList() {
+        Set<ProductCategory> validProductCategories = EnumSet.allOf(ProductCategory.class);
+
+        for (ProductCategory category : productCategoryList) {
+            if (!validProductCategories.contains(category) || category == ProductCategory.DISABLING) {
+                throw new ProductDTOException("Invalid product category: " + category);
+            }
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @NotNull List<ProductCategory> productCategoryList;
+
+        private Builder() {
+        }
+
+        public Builder productCategoryList(@NotNull List<ProductCategory> val) {
+            productCategoryList = val;
+            return this;
+        }
+
+        public TrackProductListQuery build() {
+            return new TrackProductListQuery(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListResponse.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListResponse.java
@@ -1,0 +1,39 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+public class TrackProductListResponse extends SelfValidating<TrackProductListResponse> {
+
+    @NotNull private final List<Product> productList;
+
+    private TrackProductListResponse(Builder builder) {
+        productList = builder.productList;
+        this.validateSelf(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @NotNull List<Product> productList;
+
+        private Builder() {
+        }
+
+        public Builder productList(@NotNull List<Product> val) {
+            productList = val;
+            return this;
+        }
+
+        public TrackProductListResponse build() {
+            return new TrackProductListResponse(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductQuery.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductQuery.java
@@ -1,4 +1,35 @@
 package com.shoes.ordering.system.domains.product.domain.application.dto.track;
 
-public class TrackProductQuery {
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+@Getter
+public class TrackProductQuery extends SelfValidating<TrackProductQuery> {
+
+    @NotNull private final UUID productId;
+
+    private TrackProductQuery(Builder builder) {
+        productId = builder.productId;
+
+        this.validateSelf(this);
+    }
+    public static Builder builder() {
+        return new Builder();
+    }
+    public static final class Builder {
+        private @NotNull UUID productId;
+
+        private Builder() {
+        }
+        public Builder productId(@NotNull UUID val) {
+            productId = val;
+            return this;
+        }
+        public TrackProductQuery build() {
+            return new TrackProductQuery(this);
+        }
+    }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductQuery.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductQuery.java
@@ -1,0 +1,4 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+public class TrackProductQuery {
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductResponse.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductResponse.java
@@ -1,0 +1,4 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+public class TrackProductResponse {
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductResponse.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductResponse.java
@@ -1,4 +1,82 @@
 package com.shoes.ordering.system.domains.product.domain.application.dto.track;
 
-public class TrackProductResponse {
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class TrackProductResponse extends SelfValidating<TrackProductResponse> {
+
+    @NotNull private final UUID productId;
+    @NotNull private final String name;
+    @NotNull private final ProductCategory productCategory;
+    @NotNull private final String description;
+    @NotNull private final Money price;
+    @NotNull private final List<String> productImages;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private TrackProductResponse(Builder builder) {
+        productId = builder.productId;
+        name = builder.name;
+        productCategory = builder.productCategory;
+        description = builder.description;
+        price = builder.price;
+        productImages = builder.productImages;
+
+        this.validateSelf(this);
+    }
+
+    public static final class Builder {
+        private @NotNull UUID productId;
+        private @NotNull String name;
+        private @NotNull ProductCategory productCategory;
+        private @NotNull String description;
+        private @NotNull Money price;
+        private @NotNull List<String> productImages;
+
+        private Builder() {
+        }
+
+        public Builder productId(@NotNull UUID val) {
+            productId = val;
+            return this;
+        }
+
+        public Builder name(@NotNull String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder productCategory(@NotNull ProductCategory val) {
+            productCategory = val;
+            return this;
+        }
+
+        public Builder description(@NotNull String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder price(@NotNull Money val) {
+            price = val;
+            return this;
+        }
+
+        public Builder productImages(@NotNull List<String> val) {
+            productImages = val;
+            return this;
+        }
+
+        public TrackProductResponse build() {
+            return new TrackProductResponse(this);
+        }
+    }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductCommand.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductCommand.java
@@ -1,0 +1,92 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.update;
+
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+public class UpdateProductCommand extends SelfValidating<UpdateProductCommand> {
+
+    @NotNull private final UUID productId;
+    @NotNull private final String name;
+    @NotNull private final ProductCategory productCategory;
+    @NotNull private final String description;
+    @NotNull private final Money price;
+    @NotNull private final  List<String> productImages;
+
+    private UpdateProductCommand(Builder builder) {
+        productId = builder.productId;
+        name = builder.name;
+        productCategory = builder.productCategory;
+        description = builder.description;
+        price = builder.price;
+        productImages = builder.productImages;
+
+        this.validateSelf(this);
+    }
+
+
+    public List<ProductImage> getProductImages() {
+        return productImages.stream()
+                .map(url -> new ProductImage(new ProductImageId(UUID.randomUUID()), url))
+                .collect(Collectors.toList());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @NotNull UUID productId;
+        private @NotNull String name;
+        private @NotNull ProductCategory productCategory;
+        private @NotNull String description;
+        private @NotNull Money price;
+        private @NotNull List<String> productImages;
+
+        private Builder() {
+        }
+
+        public Builder productId(@NotNull UUID val) {
+            productId = val;
+            return this;
+        }
+
+        public Builder name(@NotNull String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder productCategory(@NotNull ProductCategory val) {
+            productCategory = val;
+            return this;
+        }
+
+        public Builder description(@NotNull String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder price(@NotNull Money val) {
+            price = val;
+            return this;
+        }
+
+        public Builder productImages(@NotNull List<String> val) {
+            productImages = val;
+            return this;
+        }
+
+        public UpdateProductCommand build() {
+            return new UpdateProductCommand(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductResponse.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductResponse.java
@@ -1,0 +1,93 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.update;
+
+import com.shoes.ordering.system.domains.common.validation.SelfValidating;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+public class UpdateProductResponse extends SelfValidating<UpdateProductResponse> {
+
+    @NotNull
+    private final UUID productId;
+    @NotNull
+    private final String name;
+    @NotNull private final ProductCategory productCategory;
+    @NotNull private final String description;
+    @NotNull private final Money price;
+    @NotNull private final List<String> productImages;
+
+    private UpdateProductResponse(Builder builder) {
+        productId = builder.productId;
+        name = builder.name;
+        productCategory = builder.productCategory;
+        description = builder.description;
+        price = builder.price;
+        productImages = builder.productImages;
+
+        this.validateSelf(this);
+    }
+
+    public List<ProductImage> getProductImages() {
+        return productImages.stream()
+                .map(url -> new ProductImage(new ProductImageId(UUID.randomUUID()), url))
+                .collect(Collectors.toList());
+    }
+
+    public static UpdateProductResponse.Builder builder() {
+        return new UpdateProductResponse.Builder();
+    }
+
+    public static final class Builder {
+        private @NotNull UUID productId;
+        private @NotNull String name;
+        private @NotNull ProductCategory productCategory;
+        private @NotNull String description;
+        private @NotNull Money price;
+        private @NotNull List<String> productImages;
+
+        private Builder() {
+        }
+
+        public Builder productId(@NotNull UUID val) {
+            productId = val;
+            return this;
+        }
+
+        public Builder name(@NotNull String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder productCategory(@NotNull ProductCategory val) {
+            productCategory = val;
+            return this;
+        }
+
+        public Builder description(@NotNull String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder price(@NotNull Money val) {
+            price = val;
+            return this;
+        }
+
+        public Builder productImages(@NotNull List<String> val) {
+            productImages = val;
+            return this;
+        }
+
+        public UpdateProductResponse build() {
+            return new UpdateProductResponse(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/CreateProductCommandHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/CreateProductCommandHandler.java
@@ -1,0 +1,31 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.helper.ProductHelper;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+public class CreateProductCommandHandler {
+
+    private final ProductHelper productHelper;
+    private final ProductDataMapper productDataMapper;
+
+    public CreateProductCommandHandler(ProductHelper productHelper,
+                                       ProductDataMapper productDataMapper) {
+        this.productHelper = productHelper;
+        this.productDataMapper = productDataMapper;
+    }
+    @Transactional
+    public CreateProductResponse createProduct(CreateProductCommand createProductCommand) {
+        ProductCreatedEvent productCreatedEvent = productHelper.persistProduct(createProductCommand);
+        log.info("Product is created with id: {}", productCreatedEvent.getProduct().getId().getValue());
+        return productDataMapper.productToCreateProductResponse(
+                productCreatedEvent.getProduct());
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandler.java
@@ -1,0 +1,41 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class TrackProductListQueryHandler {
+
+    private final ProductDataMapper productDataMapper;
+    private final ProductRepository productRepository;
+
+    public TrackProductListQueryHandler(ProductDataMapper productDataMapper,
+                                        ProductRepository productRepository) {
+        this.productDataMapper = productDataMapper;
+        this.productRepository = productRepository;
+    }
+
+    @Transactional
+    public TrackProductListResponse trackProductWithCategory(TrackProductListQuery trackProductListQuery) {
+        Optional<List<Product>> resultProductList =
+                productRepository.findByProductCategory(trackProductListQuery.getProductCategoryList());
+
+        if (resultProductList.isEmpty()) {
+            log.warn("Could not fine product with product category: {}", trackProductListQuery.getProductCategoryList());
+            throw new ProductNotFoundException("Could not fine product with product category: "
+                    + trackProductListQuery.getProductCategoryList());
+        }
+        return productDataMapper.productListToTrackProductListResponse(resultProductList.get());
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandler.java
@@ -1,9 +1,40 @@
 package com.shoes.ordering.system.domains.product.domain.application.handler;
 
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Component
 public class TrackProductQueryHandler {
+
+    private final ProductDataMapper productDataMapper;
+    private final ProductRepository productRepository;
+
+
+    public TrackProductQueryHandler(ProductDataMapper productDataMapper,
+                                    ProductRepository productRepository) {
+        this.productDataMapper = productDataMapper;
+        this.productRepository = productRepository;
+    }
+
+    @Transactional
+    public TrackProductResponse trackProduct(TrackProductQuery trackProductQuery) {
+        Optional<Product> resultProduct = productRepository.findByProductId(trackProductQuery.getProductId());
+
+        if (resultProduct.isEmpty()) {
+            log.warn("Could not find product with productId: {}", trackProductQuery.getProductId());
+            throw new ProductNotFoundException("Could not find product with productId: " + trackProductQuery.getProductId());
+        }
+        return productDataMapper.productToTrackProductResponse(resultProduct.get());
+    }
+
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandler.java
@@ -1,0 +1,9 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TrackProductQueryHandler {
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/UpdateProductCommandHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/UpdateProductCommandHandler.java
@@ -1,0 +1,29 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.helper.ProductHelper;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UpdateProductCommandHandler {
+
+    private final ProductHelper productHelper;
+    private final ProductDataMapper productDataMapper;
+
+    public UpdateProductCommandHandler(ProductHelper productHelper,
+                                       ProductDataMapper productDataMapper) {
+        this.productHelper = productHelper;
+        this.productDataMapper = productDataMapper;
+    }
+
+    public UpdateProductResponse updateProduct(UpdateProductCommand updateProductCommand) {
+        ProductUpdatedEvent productUpdatedEvent = productHelper.updateProductPersist(updateProductCommand);
+        log.info("Product is updated with id: {}", productUpdatedEvent.getProduct().getId().getValue());
+        return productDataMapper.productToUpdateProductResponse(productUpdatedEvent.getProduct());
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelper.java
@@ -1,0 +1,47 @@
+package com.shoes.ordering.system.domains.product.domain.application.helper;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.ProductDomainService;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductDomainException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ProductHelper {
+
+    private final ProductDomainService productDomainService;
+    private final ProductRepository productRepository;
+    private final ProductDataMapper productDataMapper;
+
+    public ProductHelper(ProductDomainService productDomainService,
+                         ProductRepository productRepository,
+                         ProductDataMapper productDataMapper) {
+        this.productDomainService = productDomainService;
+        this.productRepository = productRepository;
+        this.productDataMapper = productDataMapper;
+    }
+
+    public ProductCreatedEvent persistProduct(CreateProductCommand createProductCommand) {
+        Product product = productDataMapper.creatProductCommandToProduct(createProductCommand);
+        ProductCreatedEvent productCreatedEvent = productDomainService.validateAndInitiateProduct(product);
+        saveProduct(product);
+
+        return productCreatedEvent;
+    }
+
+    private Product saveProduct(Product product) {
+        Product productResult = productRepository.save(product);
+        if (productResult == null) {
+            log.error("Could not save product!");
+            throw new ProductDomainException("Could not save product");
+        }
+
+        log.info("Product is saved with id: {}", product.getId().getValue());
+        return productResult;
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelper.java
@@ -1,14 +1,20 @@
 package com.shoes.ordering.system.domains.product.domain.application.helper;
 
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
 import com.shoes.ordering.system.domains.product.domain.core.ProductDomainService;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
 import com.shoes.ordering.system.domains.product.domain.core.exception.ProductDomainException;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -43,5 +49,24 @@ public class ProductHelper {
 
         log.info("Product is saved with id: {}", product.getId().getValue());
         return productResult;
+    }
+
+    public ProductUpdatedEvent updateProductPersist(UpdateProductCommand updateProductCommand) {
+        checkProduct(updateProductCommand.getProductId());
+        Product product = productDataMapper.updateProductCommandToProduct(updateProductCommand);
+        ProductUpdatedEvent productUpdatedEvent = productDomainService.validateAndUpdateProduct(product);
+
+        saveProduct(product);
+        log.info("Product is updated with id: {}", productUpdatedEvent.getProduct().getId().getValue());
+
+        return productUpdatedEvent;
+    }
+
+    private void checkProduct(UUID productId) {
+        Optional<Product> product = productRepository.findByProductId(productId);
+        if (product.isEmpty()) {
+            log.warn("Could not find product with productId: {}", productId);
+            throw new ProductNotFoundException("Could not find product with productId: " + productId);
+        }
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -51,4 +51,15 @@ public class ProductDataMapper {
                 .productImages(product.getProductImages())
                 .build();
     }
+
+    public TrackProductResponse productToTrackProductResponse(Product product) {
+        return TrackProductResponse.builder()
+                .productId(product.getId().getValue())
+                .name(product.getName())
+                .productCategory(product.getProductCategory())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .productImages(product.getProductImages())
+                .build();
+    }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -63,4 +63,10 @@ public class ProductDataMapper {
                 .productImages(product.getProductImages())
                 .build();
     }
+
+    public TrackProductListResponse productListToTrackProductListResponse(List<Product> products) {
+        return TrackProductListResponse.builder()
+                .productList(products)
+                .build();
+    }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -1,0 +1,29 @@
+package com.shoes.ordering.system.domains.product.domain.application.mapper;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductDataMapper {
+    public Product creatProductCommandToProduct(CreateProductCommand createProductCommand) {
+        return Product.builder()
+                .name(createProductCommand.getName())
+                .productCategory(createProductCommand.getProductCategory())
+                .description(createProductCommand.getDescription())
+                .price(createProductCommand.getPrice())
+                .productImages(createProductCommand.getProductImages())
+                .build();
+    }
+
+    public CreateProductResponse productToCreateProductResponse(Product product) {
+        return CreateProductResponse.builder()
+                .name(product.getName())
+                .productCategory(product.getProductCategory())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .productImages(product.getProductImages())
+                .build();
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -2,6 +2,7 @@ package com.shoes.ordering.system.domains.product.domain.application.mapper;
 
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -2,12 +2,15 @@ package com.shoes.ordering.system.domains.product.domain.application.mapper;
 
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class ProductDataMapper {

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -2,7 +2,10 @@ package com.shoes.ordering.system.domains.product.domain.application.mapper;
 
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,6 +27,17 @@ public class ProductDataMapper {
                 .description(product.getDescription())
                 .price(product.getPrice())
                 .productImages(product.getProductImages())
+                .build();
+    }
+
+    public Product updateProductCommandToProduct(UpdateProductCommand updateProductCommand) {
+        return Product.builder()
+                .productId(new ProductId(updateProductCommand.getProductId()))
+                .name(updateProductCommand.getName())
+                .description(updateProductCommand.getDescription())
+                .productCategory(updateProductCommand.getProductCategory())
+                .price(updateProductCommand.getPrice())
+                .productImages(updateProductCommand.getProductImages())
                 .build();
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/mapper/ProductDataMapper.java
@@ -40,4 +40,15 @@ public class ProductDataMapper {
                 .productImages(updateProductCommand.getProductImages())
                 .build();
     }
+
+    public UpdateProductResponse productToUpdateProductResponse(Product product) {
+        return UpdateProductResponse.builder()
+                .productId(product.getId().getValue())
+                .name(product.getName())
+                .productCategory(product.getProductCategory())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .productImages(product.getProductImages())
+                .build();
+    }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductApplicationService.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductApplicationService.java
@@ -1,0 +1,16 @@
+package com.shoes.ordering.system.domains.product.domain.application.ports.input.service;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
+
+import javax.validation.Valid;
+
+public interface ProductApplicationService {
+    CreateProductResponse createProduct(@Valid CreateProductCommand createProductCommand);
+    UpdateProductResponse updateProduct(@Valid UpdateProductCommand updateProductCommand);
+    TrackProductResponse trackProduct(@Valid TrackProductQuery trackProductQuery);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductApplicationService.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductApplicationService.java
@@ -2,8 +2,6 @@ package com.shoes.ordering.system.domains.product.domain.application.ports.input
 
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
 
@@ -12,5 +10,4 @@ import javax.validation.Valid;
 public interface ProductApplicationService {
     CreateProductResponse createProduct(@Valid CreateProductCommand createProductCommand);
     UpdateProductResponse updateProduct(@Valid UpdateProductCommand updateProductCommand);
-    TrackProductResponse trackProduct(@Valid TrackProductQuery trackProductQuery);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductQueryService.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductQueryService.java
@@ -1,10 +1,14 @@
 package com.shoes.ordering.system.domains.product.domain.application.ports.input.service;
 
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 
 import javax.validation.Valid;
+import java.util.List;
 
 public interface ProductQueryService {
     TrackProductResponse trackProduct(@Valid TrackProductQuery trackProductQuery);
+    List<TrackProductListResponse> trackProductWithCategory(@Valid TrackProductListQuery trackProductListQuery);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductQueryService.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductQueryService.java
@@ -1,0 +1,10 @@
+package com.shoes.ordering.system.domains.product.domain.application.ports.input.service;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+
+import javax.validation.Valid;
+
+public interface ProductQueryService {
+    TrackProductResponse trackProduct(@Valid TrackProductQuery trackProductQuery);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductQueryService.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/input/service/ProductQueryService.java
@@ -6,9 +6,8 @@ import com.shoes.ordering.system.domains.product.domain.application.dto.track.Tr
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 
 import javax.validation.Valid;
-import java.util.List;
 
 public interface ProductQueryService {
     TrackProductResponse trackProduct(@Valid TrackProductQuery trackProductQuery);
-    List<TrackProductListResponse> trackProductWithCategory(@Valid TrackProductListQuery trackProductListQuery);
+    TrackProductListResponse trackProductWithCategory(@Valid TrackProductListQuery trackProductListQuery);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/output/repository/ProductRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/output/repository/ProductRepository.java
@@ -1,0 +1,17 @@
+package com.shoes.ordering.system.domains.product.domain.application.ports.output.repository;
+
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public interface ProductRepository {
+
+    Product save(Product product);
+
+    Optional<Product> findByProductId(UUID productId);
+    Optional<Product> findByProductCategory(ProductCategory productCategory);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/output/repository/ProductRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/output/repository/ProductRepository.java
@@ -4,6 +4,7 @@ import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,5 +14,5 @@ public interface ProductRepository {
     Product save(Product product);
 
     Optional<Product> findByProductId(UUID productId);
-    Optional<Product> findByProductCategory(ProductCategory productCategory);
+    Optional<List<Product>> findByProductCategory(List<ProductCategory> productCategory);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainService.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainService.java
@@ -1,0 +1,12 @@
+package com.shoes.ordering.system.domains.product.domain.core;
+
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface ProductDomainService {
+     ProductCreatedEvent validateAndInitiateProduct(Product product);
+     ProductUpdatedEvent validateAndUpdateProduct(Product product);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImpl.java
@@ -1,0 +1,26 @@
+package com.shoes.ordering.system.domains.product.domain.core;
+
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Slf4j
+public class ProductDomainServiceImpl implements ProductDomainService{
+    private static final String UTC = "UTC";
+    @Override
+    public ProductCreatedEvent validateAndInitiateProduct(Product product) {
+        product.initializeProduct();
+        product.validateProduct();
+        log.info("Product with id: {} is created", product.getId().getValue());
+        return new ProductCreatedEvent(product, ZonedDateTime.now(ZoneId.of(UTC)));
+    }
+
+    @Override
+    public ProductUpdatedEvent validateAndUpdateProduct(Product product) {
+        return null;
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImpl.java
@@ -21,6 +21,8 @@ public class ProductDomainServiceImpl implements ProductDomainService{
 
     @Override
     public ProductUpdatedEvent validateAndUpdateProduct(Product product) {
-        return null;
+        product.validateUpdateProduct();
+        log.info("Product with Id: {} is changed", product.getId().getValue());
+        return new ProductUpdatedEvent(product, ZonedDateTime.now(ZoneId.of(UTC)));
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -2,10 +2,13 @@ package com.shoes.ordering.system.domains.product.domain.core.entity;
 
 import com.shoes.ordering.system.domains.common.entity.AggregateRoot;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductDomainException;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 public class Product extends AggregateRoot<ProductId> {
 
@@ -14,6 +17,10 @@ public class Product extends AggregateRoot<ProductId> {
     private final String description;
     private final Money price;
     private final List<ProductImage> productImages;
+
+    public static Builder builder() {
+        return new Builder();
+    }
 
     public Product(String name,
                    ProductCategory productCategory,
@@ -25,6 +32,27 @@ public class Product extends AggregateRoot<ProductId> {
         this.description = description;
         this.price = price;
         this.productImages = productImages;
+    }
+
+    public void initializeProduct() {
+        setId(new ProductId(UUID.randomUUID()));
+    }
+
+    public void validateProduct() {
+        validateProductCategory();
+        validatePrice();
+    }
+
+    private void validatePrice() {
+        if (price == null || !price.isGreaterThanZero()) {
+            throw new ProductDomainException("Price must be greater than zero!");
+        }
+    }
+
+    private void validateProductCategory() {
+        if (productCategory.equals(ProductCategory.DISABLING) || getId() ==null) {
+            throw new ProductDomainException("Product is not a valid category for creating the product");
+        }
     }
 
     private Product(Builder builder) {
@@ -46,10 +74,6 @@ public class Product extends AggregateRoot<ProductId> {
         private List<ProductImage> productImages;
 
         private Builder() {
-        }
-
-        public static Builder builder() {
-            return new Builder();
         }
 
         public Builder productId(ProductId val) {

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -6,7 +6,6 @@ import com.shoes.ordering.system.domains.product.domain.core.exception.ProductDo
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -38,6 +38,11 @@ public class Product extends AggregateRoot<ProductId> {
         setId(new ProductId(UUID.randomUUID()));
     }
 
+    public void validateUpdateProduct() {
+        // 업데이트 시, 도메인로직(비즈니스규칙) 추가
+        validateProduct();
+    }
+
     public void validateProduct() {
         validateProductCategory();
         validatePrice();

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -8,6 +8,7 @@ import com.shoes.ordering.system.domains.product.domain.core.valueobject.Product
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class Product extends AggregateRoot<ProductId> {
 
@@ -113,5 +114,27 @@ public class Product extends AggregateRoot<ProductId> {
         public Product build() {
             return new Product(this);
         }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ProductCategory getProductCategory() {
+        return productCategory;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Money getPrice() {
+        return price;
+    }
+
+    public List<String> getProductImages() {
+        return productImages.stream()
+                .map(ProductImage::getImageUrl)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -1,0 +1,89 @@
+package com.shoes.ordering.system.domains.product.domain.core.entity;
+
+import com.shoes.ordering.system.domains.common.entity.AggregateRoot;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+
+import java.util.List;
+
+public class Product extends AggregateRoot<ProductId> {
+
+    private final String name;
+    private final ProductCategory productCategory;
+    private final String description;
+    private final Money price;
+    private final List<ProductImage> productImages;
+
+    public Product(String name,
+                   ProductCategory productCategory,
+                   String description,
+                   Money price,
+                   List<ProductImage> productImages) {
+        this.name = name;
+        this.productCategory = productCategory;
+        this.description = description;
+        this.price = price;
+        this.productImages = productImages;
+    }
+
+    private Product(Builder builder) {
+        super.setId(builder.productId);
+        name = builder.name;
+        productCategory = builder.productCategory;
+        description = builder.description;
+        price = builder.price;
+        productImages = builder.productImages;
+    }
+
+
+    public static final class Builder {
+        private ProductId productId;
+        private String name;
+        private ProductCategory productCategory;
+        private String description;
+        private Money price;
+        private List<ProductImage> productImages;
+
+        private Builder() {
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Builder productId(ProductId val) {
+            productId = val;
+            return this;
+        }
+
+        public Builder name(String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder productCategory(ProductCategory val) {
+            productCategory = val;
+            return this;
+        }
+
+        public Builder description(String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder price(Money val) {
+            price = val;
+            return this;
+        }
+
+        public Builder productImages(List<ProductImage> val) {
+            productImages = val;
+            return this;
+        }
+
+        public Product build() {
+            return new Product(this);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -134,7 +134,7 @@ public class Product extends AggregateRoot<ProductId> {
 
     public List<String> getProductImages() {
         return productImages.stream()
-                .map(ProductImage::getImageUrl)
+                .map(ProductImage::getProductImageUrl)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/Product.java
@@ -55,7 +55,7 @@ public class Product extends AggregateRoot<ProductId> {
     }
 
     private void validateProductCategory() {
-        if (productCategory.equals(ProductCategory.DISABLING) || getId() ==null) {
+        if (productCategory.equals(ProductCategory.DISABLING) || getId() == null) {
             throw new ProductDomainException("Product is not a valid category for creating the product");
         }
     }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductImage.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductImage.java
@@ -1,0 +1,14 @@
+package com.shoes.ordering.system.domains.product.domain.core.entity;
+
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+
+public class ProductImage {
+
+    private final ProductImageId productImageId;
+    private final String imageUrl;
+
+    public ProductImage(ProductImageId productImageId, String imageUrl) {
+        this.productImageId = productImageId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductImage.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductImage.java
@@ -1,7 +1,9 @@
 package com.shoes.ordering.system.domains.product.domain.core.entity;
 
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import lombok.Getter;
 
+@Getter
 public class ProductImage {
 
     private final ProductImageId productImageId;

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductImage.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductImage.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 public class ProductImage {
 
     private final ProductImageId productImageId;
-    private final String imageUrl;
+    private final String productImageUrl;
 
-    public ProductImage(ProductImageId productImageId, String imageUrl) {
+    public ProductImage(ProductImageId productImageId, String productImageUrl) {
         this.productImageId = productImageId;
-        this.imageUrl = imageUrl;
+        this.productImageUrl = productImageUrl;
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductCreatedEvent.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.shoes.ordering.system.domains.product.domain.core.event;
+
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+
+import java.time.ZonedDateTime;
+
+public class ProductCreatedEvent extends ProductEvent{
+    protected ProductCreatedEvent(Product product, ZonedDateTime createdAt) {
+        super(product, createdAt);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductCreatedEvent.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductCreatedEvent.java
@@ -5,7 +5,7 @@ import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import java.time.ZonedDateTime;
 
 public class ProductCreatedEvent extends ProductEvent{
-    protected ProductCreatedEvent(Product product, ZonedDateTime createdAt) {
+    public ProductCreatedEvent(Product product, ZonedDateTime createdAt) {
         super(product, createdAt);
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductEvent.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductEvent.java
@@ -1,0 +1,25 @@
+package com.shoes.ordering.system.domains.product.domain.core.event;
+
+import com.shoes.ordering.system.domains.common.event.DomainEvent;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+
+import java.time.ZonedDateTime;
+
+public abstract class ProductEvent implements DomainEvent<Product> {
+    private final Product product;
+    private final ZonedDateTime createdAt;
+
+    protected ProductEvent(Product product, ZonedDateTime createdAt) {
+        this.product = product;
+        this.createdAt = createdAt;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public ZonedDateTime getCreatedAt() {
+        return createdAt;
+    }
+}
+

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductUpdatedEvent.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductUpdatedEvent.java
@@ -5,7 +5,7 @@ import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import java.time.ZonedDateTime;
 
 public class ProductUpdatedEvent extends ProductEvent{
-    protected ProductUpdatedEvent(Product product, ZonedDateTime createdAt) {
+    public ProductUpdatedEvent(Product product, ZonedDateTime createdAt) {
         super(product, createdAt);
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductUpdatedEvent.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/event/ProductUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.shoes.ordering.system.domains.product.domain.core.event;
+
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+
+import java.time.ZonedDateTime;
+
+public class ProductUpdatedEvent extends ProductEvent{
+    protected ProductUpdatedEvent(Product product, ZonedDateTime createdAt) {
+        super(product, createdAt);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/exception/ProductDomainException.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/exception/ProductDomainException.java
@@ -1,0 +1,13 @@
+package com.shoes.ordering.system.domains.product.domain.core.exception;
+
+import com.shoes.ordering.system.domains.common.exception.DomainException;
+
+public class ProductDomainException extends DomainException {
+    public ProductDomainException(String message) {
+        super(message);
+    }
+
+    public ProductDomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/exception/ProductNotFoundException.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/exception/ProductNotFoundException.java
@@ -1,0 +1,13 @@
+package com.shoes.ordering.system.domains.product.domain.core.exception;
+
+import com.shoes.ordering.system.domains.common.exception.DomainException;
+
+public class ProductNotFoundException extends DomainException {
+    public ProductNotFoundException(String message) {
+        super(message);
+    }
+
+    public ProductNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductCategory.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductCategory.java
@@ -1,0 +1,5 @@
+package com.shoes.ordering.system.domains.product.domain.core.valueobject;
+
+public enum ProductCategory {
+    SHOES, CLOTHING
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductCategory.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductCategory.java
@@ -1,5 +1,5 @@
 package com.shoes.ordering.system.domains.product.domain.core.valueobject;
 
 public enum ProductCategory {
-    SHOES, CLOTHING
+    SHOES, CLOTHING, DISABLING
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductId.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductId.java
@@ -1,0 +1,12 @@
+package com.shoes.ordering.system.domains.product.domain.core.valueobject;
+
+import com.shoes.ordering.system.domains.common.valueobject.BaseId;
+
+import java.util.UUID;
+
+public class ProductId extends BaseId<UUID> {
+
+    public ProductId(UUID value) {
+        super(value);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductImageId.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductImageId.java
@@ -1,0 +1,11 @@
+package com.shoes.ordering.system.domains.product.domain.core.valueobject;
+
+import com.shoes.ordering.system.domains.common.valueobject.BaseId;
+
+import java.util.UUID;
+
+public class ProductImageId extends BaseId<UUID> {
+    protected ProductImageId(UUID value) {
+        super(value);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductImageId.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/core/valueobject/ProductImageId.java
@@ -5,7 +5,7 @@ import com.shoes.ordering.system.domains.common.valueobject.BaseId;
 import java.util.UUID;
 
 public class ProductImageId extends BaseId<UUID> {
-    protected ProductImageId(UUID value) {
+    public ProductImageId(UUID value) {
         super(value);
     }
 }

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -1,18 +1,27 @@
-package com.shoes.ordering.system.domains.member.domain.application;
+package com.shoes.ordering.system;
 
 import com.shoes.ordering.system.domains.member.domain.application.ports.output.repository.MemberRepository;
 import com.shoes.ordering.system.domains.member.domain.core.MemberDomainService;
 import com.shoes.ordering.system.domains.member.domain.core.MemberDomainServiceImpl;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.ProductDomainService;
+import com.shoes.ordering.system.domains.product.domain.core.ProductDomainServiceImpl;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication(scanBasePackages = "com.shoes.ordering.system")
-public class MemberTestConfiguration {
+public class TestConfiguration {
 
     @Bean
     public MemberRepository memberRepository() { return Mockito.mock(MemberRepository.class); }
 
     @Bean
     public MemberDomainService memberDomainService() { return new MemberDomainServiceImpl(); }
+
+    @Bean
+    public ProductRepository productRepository() { return Mockito.mock(ProductRepository.class); }
+
+    @Bean
+    public ProductDomainService productDomainService() { return new ProductDomainServiceImpl(); }
 }

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/MemberApplicationServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/MemberApplicationServiceTest.java
@@ -1,5 +1,6 @@
 package com.shoes.ordering.system.domains.member.domain.application;
 
+import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.member.domain.application.dto.MemberAddress;
 import com.shoes.ordering.system.domains.member.domain.application.dto.create.CreateMemberCommand;
 import com.shoes.ordering.system.domains.member.domain.application.dto.create.CreateMemberResponse;
@@ -30,7 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@SpringBootTest(classes = MemberTestConfiguration.class)
+@SpringBootTest(classes = TestConfiguration.class)
 public class MemberApplicationServiceTest {
 
     @Autowired

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/MemberApplicationServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/MemberApplicationServiceTest.java
@@ -91,6 +91,7 @@ public class MemberApplicationServiceTest {
                 .name(member.getName())
                 .password(member.getPassword())
                 .email(member.getEmail())
+                .memberKind(MemberKind.CUSTOMER)
                 .memberStatus(MemberStatus.ACTIVATE)
                 .phoneNumber(member.getPhoneNumber())
                 .address(member.getAddress())
@@ -116,6 +117,7 @@ public class MemberApplicationServiceTest {
                 .password(member.getPassword())
                 .email(member.getEmail())
                 .memberStatus(MemberStatus.ACTIVATE)
+                .memberKind(MemberKind.CUSTOMER)
                 .phoneNumber(member.getPhoneNumber())
                 .address(member.getAddress())
                 .build();

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceTest.java
@@ -4,6 +4,8 @@ import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductApplicationService;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
@@ -18,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +38,7 @@ public class ProductApplicationServiceTest {
     private ProductRepository productRepository;
 
     private CreateProductCommand createProductCommand;
+    private UpdateProductCommand updateProductCommand;
 
     @BeforeEach
     public void init() {
@@ -50,7 +54,17 @@ public class ProductApplicationServiceTest {
         product.initializeProduct();
         product.validateProduct();
 
+        updateProductCommand = UpdateProductCommand.builder()
+                .productId(product.getId().getValue())
+                .name("UpdateTestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Update Test Description")
+                .price(new Money(new BigDecimal("100.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
+
         when(productRepository.save(any(Product.class))).thenReturn(product);
+        when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.ofNullable(product));
     }
 
     @Test
@@ -64,5 +78,19 @@ public class ProductApplicationServiceTest {
         // then
         assertThat(createProductResponse.getName()).isEqualTo(createProductCommand.getName());
         assertThat(createProductResponse.getDescription()).isEqualTo(createProductCommand.getDescription());
+    }
+
+    @Test
+    @DisplayName("정상 Product 업데이트 확인")
+    public void updateProductTest() {
+        // given: BeforeEach 에 포함됨
+
+        // when
+        UpdateProductResponse updateProductResponse = productApplicationService.updateProduct(updateProductCommand);
+
+        // then
+        assertThat(updateProductResponse).isNotNull();
+        assertThat(updateProductResponse.getName()).isEqualTo(updateProductCommand.getName());
+        assertThat(updateProductResponse.getDescription()).isEqualTo(updateProductCommand.getDescription());
     }
 }

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceTest.java
@@ -1,0 +1,68 @@
+package com.shoes.ordering.system.domains.product.domain.application;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductApplicationService;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class ProductApplicationServiceTest {
+
+    @Autowired
+    private ProductApplicationService productApplicationService;
+    @Autowired
+    private ProductDataMapper productDataMapper;
+    @Autowired
+    private ProductRepository productRepository;
+
+    private CreateProductCommand createProductCommand;
+
+    @BeforeEach
+    public void init() {
+        createProductCommand = CreateProductCommand.builder()
+                .name("TestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
+
+        Product product = productDataMapper.creatProductCommandToProduct(createProductCommand);
+        product.initializeProduct();
+        product.validateProduct();
+
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+    }
+
+    @Test
+    @DisplayName("정상 Product 생성 확인")
+    public void createProductTest() {
+        // given: BeforeEach 에 포함됨
+
+        // when
+        CreateProductResponse createProductResponse = productApplicationService.createProduct(createProductCommand);
+
+        // then
+        assertThat(createProductResponse.getName()).isEqualTo(createProductCommand.getName());
+        assertThat(createProductResponse.getDescription()).isEqualTo(createProductCommand.getDescription());
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductApplicationServiceTest.java
@@ -6,11 +6,13 @@ import com.shoes.ordering.system.domains.product.domain.application.dto.create.C
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
-import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductApplicationService;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,35 +36,25 @@ public class ProductApplicationServiceTest {
     @Autowired
     private ProductApplicationService productApplicationService;
     @Autowired
-    private ProductDataMapper productDataMapper;
-    @Autowired
     private ProductRepository productRepository;
 
     private CreateProductCommand createProductCommand;
     private UpdateProductCommand updateProductCommand;
+    private Product product;
 
     @BeforeEach
     public void init() {
-        createProductCommand = CreateProductCommand.builder()
-                .name("TestName")
+        product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .name("Test name")
                 .productCategory(ProductCategory.SHOES)
                 .description("Test Description")
                 .price(new Money(new BigDecimal("200.00")))
-                .productImages(List.of("testURL1", "testURL2"))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
                 .build();
 
-        Product product = productDataMapper.creatProductCommandToProduct(createProductCommand);
         product.initializeProduct();
         product.validateProduct();
-
-        updateProductCommand = UpdateProductCommand.builder()
-                .productId(product.getId().getValue())
-                .name("UpdateTestName")
-                .productCategory(ProductCategory.SHOES)
-                .description("Update Test Description")
-                .price(new Money(new BigDecimal("100.00")))
-                .productImages(List.of("testURL1", "testURL2"))
-                .build();
 
         when(productRepository.save(any(Product.class))).thenReturn(product);
         when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.ofNullable(product));
@@ -70,7 +63,14 @@ public class ProductApplicationServiceTest {
     @Test
     @DisplayName("정상 Product 생성 확인")
     public void createProductTest() {
-        // given: BeforeEach 에 포함됨
+        // given
+        createProductCommand = CreateProductCommand.builder()
+                .name("TestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of("TestUrl"))
+                .build();
 
         // when
         CreateProductResponse createProductResponse = productApplicationService.createProduct(createProductCommand);
@@ -78,12 +78,21 @@ public class ProductApplicationServiceTest {
         // then
         assertThat(createProductResponse.getName()).isEqualTo(createProductCommand.getName());
         assertThat(createProductResponse.getDescription()).isEqualTo(createProductCommand.getDescription());
+        assertThat(createProductResponse.getProductImages().size()).isEqualTo(createProductCommand.getProductImages().size());
     }
 
     @Test
     @DisplayName("정상 Product 업데이트 확인")
     public void updateProductTest() {
-        // given: BeforeEach 에 포함됨
+        // given
+        updateProductCommand = UpdateProductCommand.builder()
+                .productId(product.getId().getValue())
+                .name("UpdateTestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Update Test Description")
+                .price(new Money(new BigDecimal("100.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
 
         // when
         UpdateProductResponse updateProductResponse = productApplicationService.updateProduct(updateProductCommand);

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceTest.java
@@ -2,6 +2,8 @@ package com.shoes.ordering.system.domains.product.domain.application;
 
 import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
@@ -37,10 +39,16 @@ public class ProductQueryServiceTest {
     private ProductQueryService productQueryService;
 
     private TrackProductQuery trackProductQuery;
-    private Product product;
+    private TrackProductListQuery trackProductListQuery;
+    private Product product1;
+    private Product product2;
+    private List<Product> productList;
+    private final List<ProductCategory> validProductCategoryList
+            = List.of(ProductCategory.SHOES, ProductCategory.CLOTHING);
+
     @BeforeEach
     public void init() {
-        product = Product.builder()
+        product1 = Product.builder()
                 .productId(new ProductId(UUID.randomUUID()))
                 .name("Test name")
                 .productCategory(ProductCategory.SHOES)
@@ -48,9 +56,20 @@ public class ProductQueryServiceTest {
                 .price(new Money(new BigDecimal("200.00")))
                 .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
                 .build();
+        product2 = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName2")
+                .description("Test Product2 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
 
-        when(productRepository.save(any(Product.class))).thenReturn(product);
-        when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.of(product));
+        productList = List.of(product1, product2);
+
+        when(productRepository.save(any(Product.class))).thenReturn(product1);
+        when(productRepository.findByProductId(product1.getId().getValue())).thenReturn(Optional.of(product1));
+        when(productRepository.findByProductCategory(validProductCategoryList)).thenReturn(Optional.of(productList));
     }
 
     @Test
@@ -58,7 +77,7 @@ public class ProductQueryServiceTest {
     public void trackProductTest() {
         // given
         trackProductQuery = TrackProductQuery.builder()
-                .productId(product.getId().getValue())
+                .productId(product1.getId().getValue())
                 .build();
 
         // when
@@ -66,8 +85,23 @@ public class ProductQueryServiceTest {
 
         // then
         assertThat(ResultTrackProductResponse).isNotNull();
-        assertThat(ResultTrackProductResponse.getProductId()).isEqualTo(product.getId().getValue());
+        assertThat(ResultTrackProductResponse.getProductId()).isEqualTo(product1.getId().getValue());
     }
 
+    @Test
+    @DisplayName("정상 TrackProductListResponse 생성 확인")
+    public void trackProductListResponseTest() {
+        // given
+        trackProductListQuery = TrackProductListQuery.builder()
+                .productCategoryList(validProductCategoryList)
+                .build();
 
+        // when
+        TrackProductListResponse resultTrackProductListResponse
+                = productQueryService.trackProductWithCategory(trackProductListQuery);
+
+        // then
+        assertThat(resultTrackProductListResponse).isNotNull();
+        assertThat(resultTrackProductListResponse.getProductList().size()).isEqualTo(productList.size());
+    }
 }

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceTest.java
@@ -1,0 +1,74 @@
+package com.shoes.ordering.system.domains.product.domain.application;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.handler.TrackProductQueryHandler;
+import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class ProductQueryServiceTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private ProductQueryService productQueryService;
+
+    private TrackProductQuery trackProductQuery;
+    private Product product;
+    @BeforeEach
+    public void init() {
+        product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .name("Test name")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Product Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.of(product));
+    }
+
+    @Test
+    @DisplayName("정상 TrackProductResponse 생성 확인")
+    public void trackProductTest() {
+        // given
+        trackProductQuery = TrackProductQuery.builder()
+                .productId(product.getId().getValue())
+                .build();
+
+        // when
+         TrackProductResponse ResultTrackProductResponse = productQueryService.trackProduct(trackProductQuery);
+
+        // then
+        assertThat(ResultTrackProductResponse).isNotNull();
+        assertThat(ResultTrackProductResponse.getProductId()).isEqualTo(product.getId().getValue());
+    }
+
+
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/ProductQueryServiceTest.java
@@ -4,7 +4,6 @@ import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
-import com.shoes.ordering.system.domains.product.domain.application.handler.TrackProductQueryHandler;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/create/CreateProductCommandTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/create/CreateProductCommandTest.java
@@ -1,0 +1,64 @@
+package com.shoes.ordering.system.domains.product.domain.application.create;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class CreateProductCommandTest {
+
+    @Test
+    @DisplayName("정상 CreateProductCommand 생성")
+    public void createProductCommandTest1() {
+
+        // given
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        // when
+        CreateProductCommand createProductCommand = CreateProductCommand.builder()
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build();
+
+        // then
+        assertThat(createProductCommand).isNotNull();
+        assertThat(createProductCommand.getName()).isEqualTo(testProductName);
+    }
+
+    @Test
+    @DisplayName("비정상 CreateProductCommand 생성: 프로퍼티에 값에는 Null 이 올 수 없다.")
+    public void createProductCommandTest2() {
+
+        //given
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        //when, then
+        assertThatThrownBy(() -> CreateProductCommand.builder()
+                .name(null) // name 프로퍼티 누락
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build()
+        ).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/create/dto/CreateProductCommandTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/create/dto/CreateProductCommandTest.java
@@ -1,4 +1,4 @@
-package com.shoes.ordering.system.domains.product.domain.application.create;
+package com.shoes.ordering.system.domains.product.domain.application.create.dto;
 
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
@@ -45,7 +45,6 @@ public class CreateProductCommandTest {
     public void createProductCommandTest2() {
 
         //given
-        String testProductName = "Test ProductName";
         ProductCategory testProductCategory = ProductCategory.SHOES;
         String testProductDescription = "Test Product Description";
         Money testProductPrice = new Money(new BigDecimal("200.00"));

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/create/dto/CreateProductResponseTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/create/dto/CreateProductResponseTest.java
@@ -1,0 +1,62 @@
+package com.shoes.ordering.system.domains.product.domain.application.create.dto;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class CreateProductResponseTest {
+    @Test
+    @DisplayName("정상 CreateProductResponse 생성")
+    public void createProductResponseTest1() {
+
+        // given
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        // when
+        CreateProductResponse createProductResponse = CreateProductResponse.builder()
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build();
+
+        // then
+        assertThat(createProductResponse).isNotNull();
+        assertThat(createProductResponse.getName()).isEqualTo(testProductName);
+    }
+
+    @Test
+    @DisplayName("비정상 CreateProductCommand 생성: 프로퍼티에 값에는 Null 이 올 수 없다.")
+    public void createProductResponseTest2() {
+
+        //given
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        //when, then
+        assertThatThrownBy(() -> CreateProductResponse.builder()
+                .name(null) // name 프로퍼티 누락
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build()
+        ).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductCommandTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductCommandTest.java
@@ -1,7 +1,6 @@
-package com.shoes.ordering.system.domains.product.domain.application.create.dto;
+package com.shoes.ordering.system.domains.product.domain.application.dto.create;
 
 import com.shoes.ordering.system.domains.common.valueobject.Money;
-import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductResponseTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/create/CreateProductResponseTest.java
@@ -1,7 +1,6 @@
-package com.shoes.ordering.system.domains.product.domain.application.create.dto;
+package com.shoes.ordering.system.domains.product.domain.application.dto.create;
 
 import com.shoes.ordering.system.domains.common.valueobject.Money;
-import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListQueryTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListQueryTest.java
@@ -1,0 +1,66 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+import com.shoes.ordering.system.domains.product.domain.application.dto.ProductDTOException;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TrackProductListQueryTest {
+
+    @Test
+    @DisplayName("정상 TrackProductListQuery 생성 확인")
+    public void trackProductListQueryTest() {
+        // given
+        List<ProductCategory> validProductCategoryList = List.of(ProductCategory.SHOES, ProductCategory.CLOTHING);
+
+        // when
+        TrackProductListQuery trackProductListQuery = TrackProductListQuery.builder()
+                .productCategoryList(validProductCategoryList)
+                .build();
+
+        // then
+        assertThat(trackProductListQuery).isNotNull();
+    }
+
+    @Test
+    @DisplayName("비정상 TrackProductListQuery 생성 확인: ProductCategory 는 null 일 수 없다.")
+    public void invalidTrackProductListQueryTest1() {
+        // given
+        List<ProductCategory> invalidProductCategoryList = null;
+
+        // when, then
+         assertThatThrownBy(() ->TrackProductListQuery.builder()
+                 .productCategoryList(invalidProductCategoryList)
+                 .build()).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    @DisplayName("비정상 TrackProductListQuery 에러 생성 확인: 이용 불가한 ProductCategory(단일) 로는 조회 할 수 없다.1")
+    public void invalidTrackProductListQueryTest2() {
+        // given
+        List<ProductCategory> invalidProductCategoryList = List.of(ProductCategory.DISABLING);
+
+        // when, then
+        assertThatThrownBy(() ->TrackProductListQuery.builder()
+                .productCategoryList(invalidProductCategoryList)
+                .build()).isInstanceOf(ProductDTOException.class);
+    }
+
+    @Test
+    @DisplayName("비정상 TrackProductListQuery 에러 생성 확인: 이용 불가한 ProductCategory(다수) 로는 조회 할 수 없다.2")
+    public void invalidTrackProductListQueryTest3() {
+        // given
+        List<ProductCategory> invalidProductCategoryList = List.of(ProductCategory.SHOES, ProductCategory.DISABLING);
+
+        // when, then
+        assertThatThrownBy(() ->TrackProductListQuery.builder()
+                .productCategoryList(invalidProductCategoryList)
+                .build()).isInstanceOf(ProductDTOException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListResponseTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductListResponseTest.java
@@ -1,0 +1,76 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TrackProductListResponseTest {
+
+    private Product product1;
+    private Product product2;
+
+    @BeforeEach
+    public void init() {
+        product1 = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName1")
+                .description("Test Product1 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        product2 = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName2")
+                .description("Test Product2 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+    }
+
+    @Test
+    @DisplayName("정상 TrackProductListResponse 생성 확인")
+    public void trackProductListResponseTest() {
+        // given
+        List<Product> products = List.of(product1, product2);
+
+        // when
+        TrackProductListResponse trackProductListResponse = TrackProductListResponse.builder()
+                .productList(products)
+                .build();
+        List<Product> resultProductList = trackProductListResponse.getProductList();
+
+        // then
+        assertThat(resultProductList.get(0).getId().getValue()).isEqualTo(products.get(0).getId().getValue());
+        assertThat(resultProductList.get(1).getId().getValue()).isEqualTo(products.get(1).getId().getValue());
+    }
+
+
+    @Test
+    @DisplayName("비정상 TrackProductListResponse 에러 확인: 프로퍼티에는 null 이 올 수 없다.")
+    public void invalidTrackProductListResponseTest() {
+        // given
+        List<Product> products = null;
+
+        // when, then
+        assertThatThrownBy(() -> TrackProductListResponse.builder()
+                .productList(products)
+                .build()).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductQueryTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductQueryTest.java
@@ -1,0 +1,41 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TrackProductQueryTest {
+
+    @Test
+    @DisplayName("정상 TrackProductQuery 생성 확인")
+    public void TrackProductQueryTest1() {
+        // given
+        UUID targetProductId = UUID.randomUUID();
+
+        // when
+        TrackProductQuery trackProductQuery = TrackProductQuery.builder()
+                .productId(targetProductId)
+                .build();
+
+        // then
+        assertThat(trackProductQuery).isNotNull();
+        assertThat(trackProductQuery.getProductId()).isEqualTo(targetProductId);
+    }
+
+    @Test
+    @DisplayName("비정상 TrackProductQuery 생성 불가 확인: 프로퍼티에는 null 이 올수 없다.")
+    public void TrackProductQueryTest2() {
+        // given
+        UUID targetProductId = UUID.randomUUID();
+
+        // when, then
+        assertThatThrownBy(() -> TrackProductQuery.builder()
+                .productId(null)
+                .build()).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductResponseTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/track/TrackProductResponseTest.java
@@ -1,0 +1,67 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.track;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TrackProductResponseTest {
+
+    @Test
+    @DisplayName("정상 TrackProductResponse 생성 확인")
+    public void trackProductResponseTest1() {
+        // given
+        UUID productId = UUID.randomUUID();
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        // when
+        TrackProductResponse trackProductResponse = TrackProductResponse.builder()
+                .productId(productId)
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build();
+
+        // then
+        assertThat(trackProductResponse).isNotNull();
+        assertThat(trackProductResponse.getProductId()).isEqualTo(productId);
+        assertThat(trackProductResponse.getDescription()).isEqualTo(testProductDescription);
+
+    }
+
+    @Test
+    @DisplayName("비정상 TrackProductResponse 생성 불가 확인")
+    public void trackProductResponseTest2() {
+        // given
+        UUID productId = UUID.randomUUID();
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        // when, then
+        assertThatThrownBy(() -> TrackProductResponse.builder()
+                .productId(null)
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build()).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductCommandTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductCommandTest.java
@@ -1,0 +1,66 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.update;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class UpdateProductCommandTest {
+
+    @Test
+    @DisplayName("정상 UpdateProductCommand 테스트")
+    public void updateProductCommandTest1() {
+        // given
+        UUID productId = UUID.randomUUID();
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        // when
+        UpdateProductCommand updateProductCommand = UpdateProductCommand.builder()
+                .productId(productId)
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build();
+
+        // then
+        assertThat(updateProductCommand).isNotNull();
+        assertThat(updateProductCommand.getName()).isEqualTo(testProductName);
+    }
+
+    @Test
+    @DisplayName("비정상 UpdateProductCommand 생성: 프로퍼티에 값에는 Null 이 올 수 없다.")
+    public void updateProductCommandTest2() {
+
+        //given
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        //when, then
+        assertThatThrownBy(() -> UpdateProductCommand.builder()
+                .productId(null) // productId 누락
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build()
+        ).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductResponseTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/dto/update/UpdateProductResponseTest.java
@@ -1,0 +1,68 @@
+package com.shoes.ordering.system.domains.product.domain.application.dto.update;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class UpdateProductResponseTest {
+
+    @Test
+    @DisplayName("정상 UpdateProductResponse 생성")
+    public void updateProductResponseTest1() {
+
+        // given
+        UUID productId = UUID.randomUUID();
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        // when
+        UpdateProductResponse updateProductResponse = UpdateProductResponse.builder()
+                .productId(productId)
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build();
+
+        // then
+        assertThat(updateProductResponse).isNotNull();
+        assertThat(updateProductResponse.getName()).isEqualTo(testProductName);
+    }
+
+    @Test
+    @DisplayName("비정상 UpdateProductCommand 생성: 프로퍼티에 값에는 Null 이 올 수 없다.")
+    public void updateProductResponseTest2() {
+
+        //given
+        String testProductName = "Test ProductName";
+        ProductCategory testProductCategory = ProductCategory.SHOES;
+        String testProductDescription = "Test Product Description";
+        Money testProductPrice = new Money(new BigDecimal("200.00"));
+        List<String> testProductImages = List.of("testURL1", "testURL2");
+
+        //when, then
+        assertThatThrownBy(() -> UpdateProductResponse.builder()
+                .productId(null) // productId 누락
+                .name(testProductName)
+                .productCategory(testProductCategory)
+                .description(testProductDescription)
+                .price(testProductPrice)
+                .productImages(testProductImages)
+                .build()
+        ).isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/CreateProductCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/CreateProductCommandHandlerTest.java
@@ -1,0 +1,68 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.helper.ProductHelper;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class CreateProductCommandHandlerTest {
+
+    @Autowired
+    private CreateProductCommandHandler createProductCommandHandler;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private ProductDataMapper productDataMapper;
+    private CreateProductCommand createProductCommand;
+
+    @BeforeEach
+    public void init() {
+        createProductCommand = CreateProductCommand.builder()
+                .name("TestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
+
+        Product product = productDataMapper.creatProductCommandToProduct(createProductCommand);
+
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+    }
+
+    @Test
+    @DisplayName("정상 CreateProductResponse 생성 확인 ")
+    public void createProductTest() {
+        // given: BeforeEach 에 포함
+
+        // when
+        CreateProductResponse resultCreateProductResponse = createProductCommandHandler.createProduct(createProductCommand);
+
+        // then
+        assertThat(resultCreateProductResponse.getName()).isEqualTo(createProductCommand.getName());
+        assertThat(resultCreateProductResponse.getDescription()).isEqualTo(createProductCommand.getDescription());
+        assertThat(resultCreateProductResponse.getProductCategory()).isEqualTo(createProductCommand.getProductCategory());
+
+
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandlerTest.java
@@ -1,0 +1,105 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductNotFoundException;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class TrackProductListQueryHandlerTest {
+
+    @Autowired
+    private  TrackProductListQueryHandler trackProductListQueryHandler;
+    @Autowired
+    private  ProductRepository productRepository;
+
+    private TrackProductListQuery trackProductListQuery;
+    private List<Product> productList;
+    private Product product1;
+    private Product product2;
+
+    private final List<ProductCategory> validProductCategoryList
+            = List.of(ProductCategory.SHOES, ProductCategory.CLOTHING);
+    private final List<ProductCategory> onlyOneProductCategoryList
+            = List.of(ProductCategory.CLOTHING);
+
+    @BeforeEach
+    public void init() {
+        product1 = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName1")
+                .description("Test Product1 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        product2 = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName2")
+                .description("Test Product2 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        productList = List.of(product1, product2);
+
+        when(productRepository.findByProductCategory(validProductCategoryList)).thenReturn(Optional.of(productList));
+    }
+
+    @Test
+    @DisplayName("정상 trackProductWithCategory 확인")
+    public void trackProductWithCategoryTest() {
+        // given
+        trackProductListQuery = TrackProductListQuery.builder()
+                .productCategoryList(validProductCategoryList)
+                .build();
+
+        // when
+        TrackProductListResponse resultTrackProductListResponse
+                = trackProductListQueryHandler.trackProductWithCategory(trackProductListQuery);
+        List<Product> resultProductList = resultTrackProductListResponse.getProductList();
+
+        // then
+        assertThat(resultTrackProductListResponse).isNotNull();
+        assertThat(resultProductList.size()).isEqualTo(productList.size());
+    }
+
+    @Test
+    @DisplayName("비정상 trackProductWithCategory 예외 확인: Product 가 존재하지 않을 경우")
+    public void invalidTrackProductWithCategoryTest() {
+        // given
+        trackProductListQuery = TrackProductListQuery.builder()
+                .productCategoryList(onlyOneProductCategoryList)
+                .build();
+
+        // when, then
+        assertThatThrownBy(()-> trackProductListQueryHandler.trackProductWithCategory(trackProductListQuery))
+                .isInstanceOf(ProductNotFoundException.class);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandlerTest.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandlerTest.java
@@ -4,7 +4,6 @@ import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
 import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
-import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
@@ -26,7 +25,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -52,7 +50,6 @@ public class TrackProductQueryHandlerTest {
                 .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
                 .build();
 
-        when(productRepository.save(any(Product.class))).thenReturn(product);
         when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.of(product));
     }
 

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductQueryHandlerTest.java
@@ -1,0 +1,91 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductNotFoundException;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class TrackProductQueryHandlerTest {
+
+    @Autowired
+    private TrackProductQueryHandler trackProductQueryHandler;
+    @Autowired
+    private ProductRepository productRepository;
+
+    private TrackProductQuery trackProductQuery;
+    private Product product;
+
+    @BeforeEach
+    public void init() {
+        product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .name("Test name")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Product Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.of(product));
+    }
+
+    @Test
+    @DisplayName("정상 TrackProductResponse 확인")
+    public void trackProductTest1() {
+        // given
+        trackProductQuery = TrackProductQuery.builder()
+                .productId(product.getId().getValue())
+                .build();
+
+        // when
+        TrackProductResponse resultTrackProductResponse = trackProductQueryHandler.trackProduct(trackProductQuery);
+
+        // then
+        assertThat(resultTrackProductResponse).isNotNull();
+        assertThat(resultTrackProductResponse.getProductId()).isEqualTo(product.getId().getValue());
+    }
+
+    @Test
+    @DisplayName("비정상 TrackProductResponse 확인: 존재하지 않는 Product 조회")
+    public void trackProductTest2() {
+        // given
+        UUID unknownProductId = UUID.randomUUID();
+
+        // when
+        trackProductQuery = TrackProductQuery.builder()
+                .productId(unknownProductId)
+                .build();
+
+        // then
+        assertThatThrownBy(() -> trackProductQueryHandler.trackProduct(trackProductQuery))
+                .isInstanceOf(ProductNotFoundException.class)
+                .hasMessageContaining("Could not find product with productId: " +  unknownProductId);
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/UpdateProductCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/UpdateProductCommandHandlerTest.java
@@ -7,7 +7,10 @@ import com.shoes.ordering.system.domains.product.domain.application.dto.update.U
 import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,20 +38,21 @@ public class UpdateProductCommandHandlerTest {
     @Autowired
     ProductDataMapper productDataMapper;
 
-    private UpdateProductCommand updateProductCommand;
+    private Product product;
 
     @BeforeEach
     public void init() {
-        updateProductCommand = UpdateProductCommand.builder()
-                .productId(UUID.randomUUID())
-                .name("UpdateTestName")
+        product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .name("Test name")
                 .productCategory(ProductCategory.SHOES)
-                .description("Update Test Description")
-                .price(new Money(new BigDecimal("100.00")))
-                .productImages(List.of("testURL1", "testURL2"))
+                .description("Test Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
                 .build();
 
-        Product product = productDataMapper.updateProductCommandToProduct(updateProductCommand);
+        product.initializeProduct();
+        product.validateProduct();
 
         when(productRepository.save(any(Product.class))).thenReturn(product);
         when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.of(product));
@@ -57,13 +61,23 @@ public class UpdateProductCommandHandlerTest {
     @Test
     @DisplayName("정상 UpdateProductResponse 생성 확인")
     public void updateProductTest() {
-        // given: BeforeEach 에 포함
+        // given
+        UpdateProductCommand updateProductCommand = UpdateProductCommand.builder()
+                .productId(product.getId().getValue())
+                .name("UpdateTestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Update Test Description")
+                .price(new Money(new BigDecimal("100.00")))
+                .productImages(List.of("TestUrl"))
+                .build();
 
         // when
         UpdateProductResponse resultUpdateProductResponse
                 = updateProductCommandHandler.updateProduct(updateProductCommand);
 
         // then
+        assertThat(resultUpdateProductResponse.getName()).isNotEqualTo(product.getName());
+
         assertThat(resultUpdateProductResponse).isNotNull();
         assertThat(resultUpdateProductResponse.getName()).isEqualTo(updateProductCommand.getName());
         assertThat(resultUpdateProductResponse.getDescription()).isEqualTo(updateProductCommand.getDescription());

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/UpdateProductCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/UpdateProductCommandHandlerTest.java
@@ -1,0 +1,72 @@
+package com.shoes.ordering.system.domains.product.domain.application.handler;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class UpdateProductCommandHandlerTest {
+
+    @Autowired
+    private UpdateProductCommandHandler updateProductCommandHandler;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    ProductDataMapper productDataMapper;
+
+    private UpdateProductCommand updateProductCommand;
+
+    @BeforeEach
+    public void init() {
+        updateProductCommand = UpdateProductCommand.builder()
+                .productId(UUID.randomUUID())
+                .name("UpdateTestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Update Test Description")
+                .price(new Money(new BigDecimal("100.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
+
+        Product product = productDataMapper.updateProductCommandToProduct(updateProductCommand);
+
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.of(product));
+    }
+
+    @Test
+    @DisplayName("정상 UpdateProductResponse 생성 확인")
+    public void updateProductTest() {
+        // given: BeforeEach 에 포함
+
+        // when
+        UpdateProductResponse resultUpdateProductResponse
+                = updateProductCommandHandler.updateProduct(updateProductCommand);
+
+        // then
+        assertThat(resultUpdateProductResponse).isNotNull();
+        assertThat(resultUpdateProductResponse.getName()).isEqualTo(updateProductCommand.getName());
+        assertThat(resultUpdateProductResponse.getDescription()).isEqualTo(updateProductCommand.getDescription());
+    }
+
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelperTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelperTest.java
@@ -29,8 +29,6 @@ public class ProductHelperTest {
     @Autowired
     private ProductRepository productRepository;
     @Autowired
-    private ProductDomainService productDomainService;
-    @Autowired
     private ProductDataMapper productDataMapper;
     @Autowired
     private ProductHelper productHelper;

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelperTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelperTest.java
@@ -1,0 +1,69 @@
+package com.shoes.ordering.system.domains.product.domain.application.helper;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
+import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
+import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
+import com.shoes.ordering.system.domains.product.domain.core.ProductDomainService;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = TestConfiguration.class)
+public class ProductHelperTest {
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private ProductDomainService productDomainService;
+    @Autowired
+    private ProductDataMapper productDataMapper;
+    @Autowired
+    private ProductHelper productHelper;
+
+    private Product product;
+    private CreateProductCommand createProductCommand;
+
+    @BeforeEach
+    public void init() {
+         createProductCommand = CreateProductCommand.builder()
+                .name("TestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
+
+         product = productDataMapper.creatProductCommandToProduct(createProductCommand);
+
+         when(productRepository.save(any(Product.class))).thenReturn(product);
+    }
+
+    @Test
+    @DisplayName("정상 CreateProductEvent 생성 확인")
+    public void persistProductTest() {
+        // given: BeforeEach 내 포함
+
+        // when
+        ProductCreatedEvent resultProductCreatedEvent = productHelper.persistProduct(createProductCommand);
+
+        // then
+        Product resultProduct = resultProductCreatedEvent.getProduct();
+        assertThat(resultProduct.getName()).isEqualTo(createProductCommand.getName());
+        assertThat(resultProduct.getDescription()).isEqualTo(createProductCommand.getDescription());
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelperTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/helper/ProductHelperTest.java
@@ -4,12 +4,14 @@ import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.product.domain.application.dto.create.CreateProductCommand;
 import com.shoes.ordering.system.domains.product.domain.application.dto.update.UpdateProductCommand;
-import com.shoes.ordering.system.domains.product.domain.application.mapper.ProductDataMapper;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
 import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
 import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,8 +34,6 @@ public class ProductHelperTest {
     @Autowired
     private ProductRepository productRepository;
     @Autowired
-    private ProductDataMapper productDataMapper;
-    @Autowired
     private ProductHelper productHelper;
 
     private Product product;
@@ -41,26 +42,16 @@ public class ProductHelperTest {
 
     @BeforeEach
     public void init() {
-         createProductCommand = CreateProductCommand.builder()
-                .name("TestName")
+        product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .name("Test name")
                 .productCategory(ProductCategory.SHOES)
                 .description("Test Description")
                 .price(new Money(new BigDecimal("200.00")))
-                .productImages(List.of("testURL1", "testURL2"))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
                 .build();
-
-        product = productDataMapper.creatProductCommandToProduct(createProductCommand);
         product.initializeProduct();
         product.validateProduct();
-
-        updateProductCommand = UpdateProductCommand.builder()
-                 .productId(product.getId().getValue())
-                 .name("UpdateTestName")
-                 .productCategory(ProductCategory.SHOES)
-                 .description("Update Test Description")
-                 .price(new Money(new BigDecimal("100.00")))
-                 .productImages(List.of("testURL1", "testURL2"))
-                 .build();
 
          when(productRepository.save(any(Product.class))).thenReturn(product);
          when(productRepository.findByProductId(product.getId().getValue())).thenReturn(Optional.ofNullable(product));
@@ -69,7 +60,14 @@ public class ProductHelperTest {
     @Test
     @DisplayName("정상 CreateProductEvent 생성 확인")
     public void persistProductTest() {
-        // given: BeforeEach 내 포함
+        // given
+        createProductCommand = CreateProductCommand.builder()
+                .name("TestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of("TestUrl"))
+                .build();
 
         // when
         ProductCreatedEvent resultProductCreatedEvent = productHelper.persistProduct(createProductCommand);
@@ -83,7 +81,15 @@ public class ProductHelperTest {
     @Test
     @DisplayName("정상 UpdateProductEvent 생성 확인")
     public void updateProductPersistTest() {
-        // given: BeforeEach 에 포함
+        // given
+        updateProductCommand = UpdateProductCommand.builder()
+                .productId(product.getId().getValue())
+                .name("UpdateTestName")
+                .productCategory(ProductCategory.SHOES)
+                .description("Update Test Description")
+                .price(new Money(new BigDecimal("100.00")))
+                .productImages(List.of("testURL1", "testURL2"))
+                .build();
 
         // when
         ProductUpdatedEvent resultProductUpdatedEvent = productHelper.updateProductPersist(updateProductCommand);

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImplTest.java
@@ -28,7 +28,6 @@ public class ProductDomainServiceImplTest {
 
         // given
         Product product = Product.builder()
-                .productId(new ProductId(UUID.randomUUID()))
                 .productCategory(ProductCategory.SHOES)
                 .description("Test Product Description")
                 .price(new Money(new BigDecimal("200.00")))

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImplTest.java
@@ -4,6 +4,7 @@ import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
 import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
@@ -40,5 +41,26 @@ public class ProductDomainServiceImplTest {
         // then
         assertThat(productCreatedEvent.getProduct()).isEqualTo(product);
         assertThat(productCreatedEvent.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("정상 ProductUpdatedEvent 생성 확인")
+    public void validateAndUpdateProductTest() {
+        // given
+        ProductId existingProductId = new ProductId(UUID.randomUUID());
+        Product updatedProduct = Product.builder()
+                .productId(existingProductId)
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Product Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        // when
+        ProductUpdatedEvent productUpdatedEvent = productDomainService.validateAndUpdateProduct(updatedProduct);
+
+        // then
+        assertThat(productUpdatedEvent.getProduct()).isEqualTo(updatedProduct);
+        assertThat(productUpdatedEvent.getCreatedAt()).isNotNull();
     }
 }

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/core/ProductDomainServiceImplTest.java
@@ -1,0 +1,44 @@
+package com.shoes.ordering.system.domains.product.domain.core;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.entity.ProductImage;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ProductDomainServiceImplTest {
+
+    private final ProductDomainService productDomainService = new ProductDomainServiceImpl();
+    @Test
+    @DisplayName("정상 ProductCreatedEvent 생성 확인")
+    public void initiateProductTest() {
+
+        // given
+        Product product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Product Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+
+        // when
+        ProductCreatedEvent productCreatedEvent = productDomainService.validateAndInitiateProduct(product);
+
+        // then
+        assertThat(productCreatedEvent.getProduct()).isEqualTo(product);
+        assertThat(productCreatedEvent.getCreatedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductTest.java
@@ -59,7 +59,7 @@ public class ProductTest {
     }
 
     @Test
-    @DisplayName("비정상 Product 생성확인: Invalid price")
+    @DisplayName("비정상 Product 생성확인: Invalid Category")
     public void validateProductCategoryTest() {
         // given
         ProductCategory invalidProductCategory = ProductCategory.DISABLING;

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/core/entity/ProductTest.java
@@ -1,0 +1,82 @@
+package com.shoes.ordering.system.domains.product.domain.core.entity;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.exception.ProductDomainException;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductImageId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class ProductTest {
+
+    @Test
+    @DisplayName("정상 Product 생성 확인")
+    public void initializeProductTest() {
+        // given
+        Product product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Product Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+        // when
+        product.initializeProduct();
+        product.validateProduct();
+
+        // then
+        assertThat(product.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("비정상 Product 생성확인: Invalid price")
+    public void validatePriceTest() {
+        // given
+        Money invalidMoney = new Money(new BigDecimal("-200.00"));
+
+        // when
+        Product invalidPriceProduct = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Product Description")
+                .price(invalidMoney)
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+        invalidPriceProduct.initializeProduct();
+
+        // then
+        assertThatThrownBy(invalidPriceProduct::validateProduct).isInstanceOf(ProductDomainException.class)
+                .hasMessageContaining("Price must be greater than zero!");
+
+    }
+
+    @Test
+    @DisplayName("비정상 Product 생성확인: Invalid price")
+    public void validateProductCategoryTest() {
+        // given
+        ProductCategory invalidProductCategory = ProductCategory.DISABLING;
+
+        // when
+        Product invalidPriceProduct = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(invalidProductCategory)
+                .description("Test Product Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .productImages(List.of(new ProductImage(new ProductImageId(UUID.randomUUID()), "TestUrl")))
+                .build();
+        invalidPriceProduct.initializeProduct();
+
+        // then
+        assertThatThrownBy(invalidPriceProduct::validateProduct).isInstanceOf(ProductDomainException.class)
+                .hasMessageContaining("Product is not a valid category for creating the product");
+
+    }
+}


### PR DESCRIPTION
## Feature/product domain

## 작업내용

> ### Product 도메인 계층 구현

![Domain-layer](https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FcpfeQ2%2FbtsmsAyWAYu%2FKCRS74fkTgx7nUjPmWEkJk%2Fimg.png)

<br>

신발 주문 시스템의 두번째 도메인 `Product` 의 `도메인 계층` 을 구현했습니다.  전체 Product 도메인 개발 중 `Domain-Core` 와 `Domain-Application` 에 해당하는 부분입니다.

- `Domain-Core`: 엔터티 및 도메인서비스가  존재합니다.
- `Domain-Application`: 유스케이스가 존재하며, Command(데이터수정), Query(데이터조회)에 따라 분리된 Service 와 이를 위한 다양한 패키지(dto, hanlder, helper 등)가 존재합니다.

이전 `Member` 도메인 계층과의 차이점으로, 지난 Member 도메인 계층에서의 개발은 `MemberApplicationService` 에서 `Command`(상태수정,저장) 과 `Query`(조회)를 모두 담당했다면, 이번 **Product 도메인 계층에서는 ProductApplicationService 와 ProductQueryService 를 나누어 개발하였습니다.**

- Command 와 Query 로 작업을 구분하여, 요청의 관심사를 명확하게 분리 하고 이를 통해, 코드의 구성과 유지 관리 및 테스트를 좀 더 쉽게 할 수 있습니다.

<br>

이에 더해 지난 피드백 사항 중 하나였던, 테스트 부족과 관련하여, 생성하는 모든 클래스의 테스트를 통한 정상 작동을 확인하는 `테스트`를 작성했습니다.

<br>

### 특이사항

> **입력 유효성 검사 추가**

지난 Member 도메인 개발 시에는 입력 유효성 검사가 누락되어, 입력 값이 잘못된 경우에도 객체가 생성되는 자원의 낭비가 발생했음을 깨닫고, 입력 유효성 검사를 추가했습니다.

```java
public abstract class SelfValidating<T> {

    private final Validator validator;
    public SelfValidating() {
        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
        validator = factory.getValidator();
    }
    protected void validateSelf(T instance) {
        Set<ConstraintViolation<T>> violations = validator.validate(instance);
        if (!violations.isEmpty()) {
            throw new ConstraintViolationException(violations);
        }
    }
}
```

<br>

> **프로젝트 패키지 구조 변경**

이전 Member의 패키지 구조가 프로젝트의 구조가 될것으로 결정하였으나, `클린아키텍처`(Port and Adapert)로서 좀 더 표현력 있는 패키지 구조를 갖고자 패키지 구조를 수정하여 개발할 예정입니다.

- 기존 패키지 구조
  - ```markdown
    domain
      ㄴcontroller
      ㄴdataaccess
      ㄴdoamin 
      ㄴmessaging 
     ``` 


- 개선 패키지 구조
  - ```markdown
    domain
      ㄴadaper
        ㄴin
          ㄴcontroller
        ㄴout
          ㄴdataaccess
          ㄴmessaging
      ㄴdomain  
     ``` 

<br><hr>

## 컨텍스트

Product 의 도메인 계층을 개발하면서, Member 도메인을 개발할 때는 생각하지 못한 부분들이 떠올라, 많이 고민하게되었다.

> **패키지 구조에 관하여**

나는 `Ports and Adapters` 패턴을 통해, 도메인 계층을 보호하면서, 테스트하기 쉽고, 확장성을 갖춘 프로젝트를 만들고자 하였다. 이에 더해 패키지 구조만을 통해 (개발하기 위한)코드를 빠르게 탐색할 수 있는 아키텍처를 만들고 싶었다. 이런 고민을 통해 구성된 것이 Member 도메인의 패키지 구조이다. 그런데 Product 도메인을 개발하면서 문득, 패키지 구조가 이게 알맞는 것일까? 하는 생각이 들었다.  

Ports 그리고 Adapter를 표현하지 않고있었다. `Controller` 는 `Input` 을 , `DataAccess` 는 `Output` 을 의미한다는 것을 나만 알고 있었다.(패키지 구조가 외치지 않고 있았다.) 그리고 이는 패키지 구조에 대한 의문이 충분히 들만했다.(내가 들었다..패키지 구조에 헷갈렸다..)

- DataAccess 내의 adapter 와 mapper 에 대하여, 특히 그랬다.

그래서 패키지 구조를 개선하기로 마음먹었다.

<br>

> **Domain 계층의  Service 의 책임**

기존의 Domain  계층에는 총 2개의 Service 가 존재한다.  그러나 이번에는 `QueryService` 를 추가했다.

- `ApplicationService`
- `DomainSercice`
- `QueryService`(**추가됨**)

클린아키텍처를 통해 도메인의 영속성계층 의존성을 뒤집고(도메인의 변경이유를 줄이기 위함), 서비스를 책임에 따라 구분지어 개발하였다. 그래서 `DomainService` 와 `ApplicationService` 로  나누어 졌다. 하지만 문득 Product 를 개발하면서 `ApplicationService` 의 책임은 무엇인가? 를 생각하게 되었다.

기존의 `ApplicationService` 에서는 `Command`(데이터수정), `Query`(데이터 조회)를 담당한다. 즉, 유스케이스를 처리한다.  유스케이스를 처리한다는 측면에서는 `ApplicationService` 의 현 상황의 모습이 적절하다. 하지만, 지난 경험 측면에서는 이를 분리하는게 어떨까 하는 생각이 들었다. 이렇게 하는게 옳다. 라고 확신은 들지 않는다... 그래서 다른 사람들의 생각이 궁금하다. 

 `Command` 와 `Query` 를 구분지어 개발하는 것이 유지보수 측면에서 더 좋을까? 책임을 세분화 해야할까?(하는것이 맞을까?)

<br>

그리고 내 고민과 생각을 잘 정리된 글로 작성하는 것이 제일 어려운 것 같다. 고민에 이를 어떻게 잘 표현할 수 있을까? 고민이 더해져 고민이 고민이된다.(눈물)