### PR TITLE
Feature/order adapter: DataAccess

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 group 'com.shoes.ordering.system'
 version '1.0-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = "16"
 
 repositories {
     mavenCentral()
@@ -120,3 +120,4 @@ configurations.all {
         }
     }
 }
+targetCompatibility = JavaVersion.VERSION_16

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/adapter/OrderPersistenceAdapter.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/adapter/OrderPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.adapter;
+
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.mapper.OrderDataAccessMapper;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository.OrderJpaRepository;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository.OrderQuerydslRepository;
+import com.shoes.ordering.system.domains.order.domain.application.ports.output.repository.OrderRepository;
+import com.shoes.ordering.system.domains.order.domain.core.entity.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class OrderPersistenceAdapter implements OrderRepository {
+
+    private final OrderJpaRepository orderJpaRepository;
+    private final OrderQuerydslRepository orderQuerydslRepository;
+    private final OrderDataAccessMapper orderDataAccessMapper;
+
+    public OrderPersistenceAdapter(OrderJpaRepository orderJpaRepository,
+                                   OrderQuerydslRepository orderQuerydslRepository,
+                                   OrderDataAccessMapper orderDataAccessMapper) {
+        this.orderJpaRepository = orderJpaRepository;
+        this.orderQuerydslRepository = orderQuerydslRepository;
+        this.orderDataAccessMapper = orderDataAccessMapper;
+    }
+
+    @Override
+    public Order save(Order order) {
+        return orderDataAccessMapper
+                .orderEntityToOrder(orderJpaRepository.save(orderDataAccessMapper.orderToOrderEntity(order)));
+    }
+
+    public Optional<Order> findByTrackingId(UUID trackingId) {
+        return orderQuerydslRepository.findByTrackingId(trackingId)
+                .map(orderDataAccessMapper::orderEntityToOrder);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderAddressEntity.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderAddressEntity.java
@@ -1,0 +1,40 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.Objects;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "order_address")
+@Entity
+public class OrderAddressEntity {
+    @Id
+    private UUID id;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "ORDER_ID")
+    private OrderEntity order;
+
+    private String street;
+    private String postalCode;
+    private String city;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OrderAddressEntity)) return false;
+        OrderAddressEntity that = (OrderAddressEntity) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderEntity.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderEntity.java
@@ -1,0 +1,47 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity;
+
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderStatus;
+import lombok.*;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "orders")
+@Entity
+public class OrderEntity {
+    @Id
+    private UUID id;
+    private UUID memberId;
+    private UUID trackingId;
+    private BigDecimal price;
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+    private String failureMessages;
+
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+    private OrderAddressEntity address;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItemEntity> items;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OrderEntity)) return false;
+        OrderEntity that = (OrderEntity) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderItemEntity.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderItemEntity.java
@@ -1,0 +1,44 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity;
+
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.entity.ProductEntity;
+import lombok.*;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(OrderItemEntityId.class)
+@Table(name = "order_items")
+@Entity
+public class OrderItemEntity {
+    @Id
+    private Long id;
+    @Id
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "ORDER_ID")
+    private OrderEntity order;
+    @ManyToOne(cascade = CascadeType.DETACH, optional = false)
+    @JoinColumn(name = "PRODUCT_ID")
+    private ProductEntity product;
+    private BigDecimal price;
+    private Integer quantity;
+    private BigDecimal subTotal;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OrderItemEntity)) return false;
+        OrderItemEntity that = (OrderItemEntity) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderItemEntityId.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/entity/OrderItemEntityId.java
@@ -1,0 +1,30 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemEntityId implements Serializable {
+
+    private Long id;
+    private OrderEntity order;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OrderItemEntityId)) return false;
+        OrderItemEntityId that = (OrderItemEntityId) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/mapper/OrderDataAccessMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/mapper/OrderDataAccessMapper.java
@@ -1,0 +1,120 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.mapper;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.common.valueobject.StreetAddress;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderAddressEntity;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderEntity;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderItemEntity;
+import com.shoes.ordering.system.domains.order.domain.core.entity.Order;
+import com.shoes.ordering.system.domains.order.domain.core.entity.OrderItem;
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderId;
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderItemId;
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.TrackingId;
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.entity.ProductEntity;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.shoes.ordering.system.domains.order.domain.core.entity.Order.FAILURE_MESSAGE_DELIMITER;
+
+@Component
+public class OrderDataAccessMapper {
+    public Order orderEntityToOrder(OrderEntity orderEntity) {
+        return Order.builder()
+                .orderId(new OrderId(orderEntity.getId()))
+                .memberId(new MemberId(orderEntity.getMemberId()))
+                .deliveryAddress(addressEntityToDeliveryAddress(orderEntity.getAddress()))
+                .price(new Money(orderEntity.getPrice()))
+                .items(orderItemEntitiesToOrderItems(orderEntity.getItems()))
+                .trackingId(new TrackingId(orderEntity.getTrackingId()))
+                .orderStatus(orderEntity.getOrderStatus())
+                .failureMessages(orderEntity.getFailureMessages().isEmpty() ? new ArrayList<>() :
+                        new ArrayList<>(Arrays.asList(orderEntity.getFailureMessages()
+                                .split(FAILURE_MESSAGE_DELIMITER))))
+                .build();
+    }
+
+    private List<OrderItem> orderItemEntitiesToOrderItems(List<OrderItemEntity> items) {
+        return items.stream()
+                .map(orderItemEntity -> OrderItem.builder()
+                        .orderItemId(new OrderItemId(orderItemEntity.getId()))
+                        .product(ProductEntityToProduct(orderItemEntity.getProduct()))
+                        .price(new Money(orderItemEntity.getPrice()))
+                        .quantity(orderItemEntity.getQuantity())
+                        .subTotal(new Money(orderItemEntity.getSubTotal()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private Product ProductEntityToProduct(ProductEntity productEntity) {
+        return Product.builder()
+                .productId(new ProductId(productEntity.getProductId()))
+                .name(productEntity.getName())
+                .price(new Money(productEntity.getPrice()))
+                .description(productEntity.getDescription())
+                .productCategory(productEntity.getProductCategory())
+                .build();
+    }
+
+    private StreetAddress addressEntityToDeliveryAddress(OrderAddressEntity address) {
+        return new StreetAddress(address.getId(),
+                address.getStreet(),
+                address.getPostalCode(),
+                address.getCity());
+    }
+
+    public OrderEntity orderToOrderEntity(Order order) {
+        OrderEntity orderEntity = OrderEntity.builder()
+                .id(order.getId().getValue())
+                .memberId(order.getMemberId().getValue())
+                .trackingId(order.getTrackingId().getValue())
+                .address(deliveryAddressToAddressEntity(order.getDeliveryAddress()))
+                .price(order.getPrice().getAmount())
+                .items(orderItemsToOrderItemEntities(order.getItems()))
+                .orderStatus(order.getOrderStatus())
+                .failureMessages(order.getFailureMessages() != null ?
+                        String.join(FAILURE_MESSAGE_DELIMITER, order.getFailureMessages()) : "")
+                .build();
+        orderEntity.getAddress().setOrder(orderEntity);
+        orderEntity.getItems().forEach(orderItemEntity -> orderItemEntity.setOrder(orderEntity));
+
+        return orderEntity;
+    }
+
+    private List<OrderItemEntity> orderItemsToOrderItemEntities(List<OrderItem> items) {
+        return items.stream()
+                .map(orderItem -> OrderItemEntity.builder()
+                        .id(orderItem.getId().getValue())
+                        .product(productToProductEntity(orderItem.getProduct()))
+                        .price(orderItem.getPrice().getAmount())
+                        .quantity(orderItem.getQuantity())
+                        .subTotal(orderItem.getSubTotal().getAmount())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public ProductEntity productToProductEntity(Product product) {
+        return  ProductEntity.builder()
+                .productId(product.getId().getValue())
+                .name(product.getName())
+                .description(product.getDescription())
+                .price(product.getPrice().getAmount())
+                .productCategory(product.getProductCategory())
+                .build();
+    }
+
+    private OrderAddressEntity deliveryAddressToAddressEntity(StreetAddress deliveryAddress) {
+        return OrderAddressEntity.builder()
+                .id(deliveryAddress.getId())
+                .street(deliveryAddress.getStreet())
+                .postalCode(deliveryAddress.getPostalCode())
+                .city(deliveryAddress.getCity())
+                .build();
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/OrderJpaRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/OrderJpaRepository.java
@@ -2,6 +2,8 @@ package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repositor
 
 import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,5 +12,6 @@ import java.util.UUID;
 @Repository
 public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID> {
 
-    Optional<OrderEntity> findByTrackingId(UUID trackingId);
+    @Query("SELECT o FROM OrderEntity o JOIN FETCH o.items WHERE o.trackingId = :trackingId")
+    Optional<OrderEntity> findByTrackingId(@Param("trackingId") UUID trackingId);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/OrderJpaRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/OrderJpaRepository.java
@@ -1,0 +1,14 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository;
+
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID> {
+
+    Optional<OrderEntity> findByTrackingId(UUID trackingId);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/OrderQuerydslRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/OrderQuerydslRepository.java
@@ -1,0 +1,10 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository;
+
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrderQuerydslRepository {
+    Optional<OrderEntity> findByTrackingId(UUID trackId);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/impl/OrderQuerydslRepositoryImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/repository/impl/OrderQuerydslRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderEntity;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository.OrderQuerydslRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.QOrderEntity.orderEntity;
+import static com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.QOrderItemEntity.orderItemEntity;
+
+@Component
+public class OrderQuerydslRepositoryImpl implements OrderQuerydslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public OrderQuerydslRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Optional<OrderEntity> findByTrackingId(UUID trackingId) {
+        return Optional.ofNullable(jpaQueryFactory
+                .select(orderEntity)
+                .from(orderEntity)
+                .leftJoin(orderEntity.items, orderItemEntity).fetchJoin()
+                .where(orderEntity.trackingId.eq(trackingId))
+                .fetchOne());
+    }
+}
+

--- a/src/main/java/com/shoes/ordering/system/domains/order/domain/application/handler/TrackOrderQueryHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/domain/application/handler/TrackOrderQueryHandler.java
@@ -28,7 +28,7 @@ public class TrackOrderQueryHandler {
 
     public TrackOrderResponse trackOrder(TrackOrderQuery trackOrderQuery) {
         Optional<Order> orderResult =
-                orderRepository.findByTrackingId(new TrackingId(trackOrderQuery.getOrderTrackingId()));
+                orderRepository.findByTrackingId(trackOrderQuery.getOrderTrackingId());
 
         if (orderResult.isEmpty()) {
             log.warn("Could not find order with tracking id: {}", trackOrderQuery.getOrderTrackingId());

--- a/src/main/java/com/shoes/ordering/system/domains/order/domain/application/ports/output/repository/OrderRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/domain/application/ports/output/repository/OrderRepository.java
@@ -1,15 +1,15 @@
 package com.shoes.ordering.system.domains.order.domain.application.ports.output.repository;
 
 import com.shoes.ordering.system.domains.order.domain.core.entity.Order;
-import com.shoes.ordering.system.domains.order.domain.core.valueobject.TrackingId;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 public interface OrderRepository {
 
     Order save(Order order);
 
-    Optional<Order> findByTrackingId(TrackingId trackingId);
+    Optional<Order> findByTrackingId(UUID trackingId);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/order/domain/core/entity/Order.java
+++ b/src/main/java/com/shoes/ordering/system/domains/order/domain/core/entity/Order.java
@@ -24,6 +24,7 @@ public class Order extends AggregateRoot<OrderId> {
     private OrderStatus orderStatus;
     private List<String> failureMessages;
 
+    public static final String FAILURE_MESSAGE_DELIMITER = ",";
     public void initializeOrder() {
         setId(new OrderId(UUID.randomUUID()));
         trackingId = new TrackingId(UUID.randomUUID());
@@ -172,7 +173,7 @@ public class Order extends AggregateRoot<OrderId> {
             return new Builder();
         }
 
-        public Builder id(OrderId val) {
+        public Builder orderId(OrderId val) {
             orderId = val;
             return this;
         }

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -1,7 +1,5 @@
 package com.shoes.ordering.system;
 
-import com.shoes.ordering.system.common.kafka.consumer.config.KafkaConsumerConfig;
-import com.shoes.ordering.system.common.kafka.producer.KafkaProducerConfig;
 import com.shoes.ordering.system.domains.member.domain.application.ports.output.repository.MemberRepository;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCancelledPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCreatedPaymentRequestMessagePublisher;
@@ -27,17 +25,6 @@ import java.io.InputStream;
 
 @SpringBootApplication(scanBasePackages = "com.shoes.ordering.system")
 public class TestConfiguration {
-
-    private final KafkaProducerConfig kafkaProducerConfig;
-
-    private static KafkaConsumerConfig kafkaConsumerConfig;
-
-    public TestConfiguration(KafkaProducerConfig kafkaProducerConfig,
-                             KafkaConsumerConfig kafkaConsumerConfig) {
-        this.kafkaProducerConfig = kafkaProducerConfig;
-        this.kafkaConsumerConfig = kafkaConsumerConfig;
-    }
-
 
     @Bean
     public MemberRepository memberRepository() { return Mockito.mock(MemberRepository.class); }

--- a/src/test/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/adapter/OrderPersistenceAdapterTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/adapter/OrderPersistenceAdapterTest.java
@@ -93,11 +93,17 @@ class OrderPersistenceAdapterTest {
 
         // then
         assertThat(result).isPresent();
+
+        List<OrderItem> items = result.get().getItems();
+        for (OrderItem item : items) {
+            System.out.println("OrderItem: " + item.getProduct().getName());
+        }
+
         assertThat(result.get().getPrice().getAmount()).isEqualTo(productPrice);
     }
 
     @Test
-    @DisplayName("정상 findByTrackingId 에러 확인")
+    @DisplayName("정상 findByTrackingId 확인: 잘못된 TrackingId 로 주문 조회 시 미존재 확인")
     void findByTrackingIdErrorTest() {
         // given
         UUID unknownOrderTrackingId = UUID.randomUUID();

--- a/src/test/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/adapter/OrderPersistenceAdapterTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/order/adapter/out/dataaccess/adapter/OrderPersistenceAdapterTest.java
@@ -1,0 +1,150 @@
+package com.shoes.ordering.system.domains.order.adapter.out.dataaccess.adapter;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.common.valueobject.StreetAddress;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.entity.OrderEntity;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.mapper.OrderDataAccessMapper;
+import com.shoes.ordering.system.domains.order.adapter.out.dataaccess.repository.OrderJpaRepository;
+import com.shoes.ordering.system.domains.order.domain.core.entity.Order;
+import com.shoes.ordering.system.domains.order.domain.core.entity.OrderItem;
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderStatus;
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.TrackingId;
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.mapper.ProductDataAccessMapper;
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductJpaRepository;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import com.shoes.ordering.system.TestConfiguration;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+
+@SpringBootTest(classes = TestConfiguration.class)
+class OrderPersistenceAdapterTest {
+
+    @Autowired
+    OrderPersistenceAdapter orderPersistenceAdapter;
+    @Autowired
+    OrderJpaRepository orderJpaRepository;
+    @Autowired
+    ProductDataAccessMapper productDataAccessMapper;
+    @Autowired
+    ProductJpaRepository productJpaRepository;
+    @Autowired
+    OrderDataAccessMapper orderDataAccessMapper;
+    private BigDecimal totalPrice = new BigDecimal("00.00");
+
+    @AfterEach
+    void clean() {
+        orderJpaRepository.deleteAll();
+        productJpaRepository.deleteAll();
+        totalPrice = new BigDecimal("00.00");
+    }
+
+    @Test
+    @DisplayName("정상 OrderEntity save 테스트")
+    void saveTest() {
+        // given
+        int productQuantity = 1;
+        BigDecimal productPrice = new BigDecimal("200.00");
+        OrderItem orderItem = createOrderItem(productQuantity, productPrice);
+
+        Order order = createOrder(totalPrice, List.of(orderItem));
+        order.initializeOrder();
+
+        // when
+        orderPersistenceAdapter.save(order);
+
+        // then
+        List<OrderEntity> results = orderJpaRepository.findAll();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isNotNull();
+        assertThat(results.get(0).getId()).isEqualTo(order.getId().getValue());
+    }
+
+    @Test
+    @DisplayName("정상 findByTrackingId 확인")
+    void findByTrackingIdTest() {
+        // given
+        int productQuantity = 1;
+        BigDecimal productPrice = new BigDecimal("200.00");
+        OrderItem orderItem = createOrderItem(productQuantity, productPrice);
+
+        Order order = createOrder(totalPrice, List.of(orderItem));
+        order.initializeOrder();
+
+        OrderEntity orderEntity = orderDataAccessMapper.orderToOrderEntity(order);
+
+        orderJpaRepository.save(orderEntity);
+
+        // when
+        Optional<Order> result = orderPersistenceAdapter.findByTrackingId(orderEntity.getTrackingId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getPrice().getAmount()).isEqualTo(productPrice);
+    }
+
+    @Test
+    @DisplayName("정상 findByTrackingId 에러 확인")
+    void findByTrackingIdErrorTest() {
+        // given
+        UUID unknownOrderTrackingId = UUID.randomUUID();
+
+        // when
+        Optional<Order> result = orderPersistenceAdapter.findByTrackingId(unknownOrderTrackingId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private Order createOrder(BigDecimal totalPrice, List<OrderItem> items) {
+        return Order.builder()
+                .trackingId(new TrackingId(UUID.randomUUID()))
+                .memberId(new MemberId(UUID.randomUUID()))
+                .deliveryAddress(new StreetAddress(UUID.randomUUID(), "123 Street", "99999", "City"))
+                .price(new Money(totalPrice))
+                .items(items)
+                .orderStatus(OrderStatus.PENDING)
+                .build();
+    }
+
+    private OrderItem createOrderItem(int quantity, BigDecimal productPrice) {
+        Product product = createProduct(productPrice);
+
+        totalPrice = totalPrice.add(productPrice.multiply(BigDecimal.valueOf(quantity)));
+
+        return OrderItem.builder()
+                .product(product)
+                .quantity(quantity)
+                .price(new Money(productPrice))
+                .subTotal(new Money(productPrice.multiply(BigDecimal.valueOf(quantity))))
+                .build();
+    }
+
+    private Product createProduct(BigDecimal productPrice) {
+        Product product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .name("Test name")
+                .productCategory(ProductCategory.SHOES)
+                .description("Test Description")
+                .price(new Money(productPrice))
+                .build();
+
+        productJpaRepository.save(productDataAccessMapper.productToProductEntity(product));
+
+        return product;
+    }
+
+}

--- a/src/test/java/com/shoes/ordering/system/domains/order/domain/application/OrderQueryServiceImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/order/domain/application/OrderQueryServiceImplTest.java
@@ -59,7 +59,7 @@ class OrderQueryServiceImplTest {
         OrderItem orderItem = createOrderItem(1, new BigDecimal("50.00"));
         Order targetOrder = createOrder(totalPrice, List.of(orderItem));
 
-        when(orderRepository.findByTrackingId(any(TrackingId.class))).thenReturn(Optional.of(targetOrder));
+        when(orderRepository.findByTrackingId(any(UUID.class))).thenReturn(Optional.of(targetOrder));
 
         // when
         TrackOrderResponse result = orderQueryService.trackOrder(trackOrderQuery);
@@ -76,7 +76,7 @@ class OrderQueryServiceImplTest {
         UUID unknownTrackingID = UUID.randomUUID();
         TrackOrderQuery wrongTrackOrderQuery = createTrackOrderQuery(unknownTrackingID);
 
-        when(orderRepository.findByTrackingId(any(TrackingId.class)))
+        when(orderRepository.findByTrackingId(any(UUID.class)))
                 .thenReturn(Optional.ofNullable(null));
 
         // when, then

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+        use_sql_comments: true
+
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## Feature/order adapter: DataAccess
## 작업 내용

> ## Order Adapter-Out.DataAccess(DB) 계층 개발

이번 작업의 목적은, 주문 데이터에 대한 DB 조작 및 조회 하기 위한  Order Adapter-Out.DataAccess(DB) 계층을 개발하는 것 입니다.

- `OrderJpaRepositoryImpl` : 간단한 CRUD 와 관련된 API 를 사용한다.
- `OrderQuerydslRepositoryImpl` : 쿼리를 작성해야 하는 경우 사용한다.

<br>

### 주요 기능

이 계층은 주문과 관련된 데이터 처리를 실제적으로 담당하며, 실제 DB와 상호작용합니다.

<br>

### 테스트

SpringBootTest 를 통해 진행했습니다.

- `OrderPersistenceAdapter` 를 검증함으로써  `OrderJpaRespository` 및 `OrderQuerydslRepository`  의 정상 기능 작동을 검증했습니다.

<br>

진행한 테스트 시나리오 는 다음과 같습니다.

> 주문 저장 및 조회 테스트 시나리오

- 시나리오: 주문을 저장하고, 저장한 주문을 조회할 때 정상적으로 동작하는지 확인한다.

- 테스트 케이스
  - 테스트 데이터 생성: 필요한 필드를 채우고, Order 엔터티를 생성한다.
  - OrderPersistenceAdapter를 사용하여 주문 저장: 생성한 Order 엔터티를 데이터베이스에 저장한다.
  - OrderPersistenceAdapter를 사용하여 주문 조회: 저장한 Order의 TrackingId를 사용하여 주문을 조회하고, 예상한 주문 데이터와 조회한 주문 데이터를 비교한다.

- 결과 비교
  - 예상한 Order 와 조회한 Order 데이터가 일치하는지 확인한다.
  -  생성한 Order 의 개수 만큼 존재하는지 확인한다.

<br>

> 주문 조회 실패 테스트 시나리오

- 시나리오: 존재하지 않는 TrackingId 로 주문을 조회했을 때 올바른 값을 반환하는지 확인한다.

- 테스트 케이스
  - 임의의 존재하지 않는 TrackingId 생성
  - OrderPersistenceAdapter를 사용하여 주문 조회: 존재하지 않는 TrackingId 로 주문을 조회했을 때 결과가 isEmpty 인지 확인한다.