### PR TITLE
Chore/kafka integration test(누락된 카프카 통합 테스트를 추가한다.)

### DIFF
--- a/src/main/java/com/shoes/ordering/system/domains/member/messaging/publisher/UpdateMemberKafkaMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/member/messaging/publisher/UpdateMemberKafkaMessagePublisher.java
@@ -34,20 +34,20 @@ public class UpdateMemberKafkaMessagePublisher implements MemberUpdateRequestMes
         log.info("Received MemberUpdatedEvent for memberId: {}", memberId);
 
         try {
-            UpdateMemberRequestAvroModel createMemberRequestAvroModel = memberMessagingDataMapper
+            UpdateMemberRequestAvroModel updateMemberRequestAvroModel = memberMessagingDataMapper
                     .memberUpdatedEventToUpdateMemberRequestAvroModel(domainEvent);
 
             kafkaProducer.send(memberServiceConfigData.getUpdateMemberRequestTopicName(),
                     memberId,
-                    createMemberRequestAvroModel,
+                    updateMemberRequestAvroModel,
                     memberKafkaMessageHelper.getKafkaCallback(memberServiceConfigData
                             .getUpdateMemberRequestTopicName(),
-                            createMemberRequestAvroModel,
+                            updateMemberRequestAvroModel,
                             memberId,
                             "UpdateMemberRequestAvroModel")
             );
-            log.info("CreateMemberRequestAvroModel sent to Kafka for member id: {}"
-                    , createMemberRequestAvroModel.getMemberId());
+            log.info("UpdateMemberRequestAvroModel sent to Kafka for member id: {}"
+                    , updateMemberRequestAvroModel.getMemberId());
         } catch (Exception e) {
             log.error("Error while sending UpdateMemberRequestAvroModel message to Kafka with member id: {}, error: {}"
                     ,memberId, e.getMessage() );

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -45,10 +45,12 @@ public class TestConfiguration {
     @Bean
     public ProductRepository productRepository() { return Mockito.mock(ProductRepository.class); }
     @Bean
+    @Primary
     public ProductCreatedRequestMessagePublisher productCreatedRequestMessagePublisher() {
         return Mockito.mock(ProductCreatedRequestMessagePublisher.class);
     }
     @Bean
+    @Primary
     public ProductUpdatedRequestMessagePublisher productUpdatedRequestMessagePublisher() {
         return Mockito.mock(ProductUpdatedRequestMessagePublisher.class);
     }
@@ -73,14 +75,18 @@ public class TestConfiguration {
         MockSchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient();
 
         // 스키마 생성
-        Schema paymentRequestAvroSchema = loadSchemaFromClasspath("avro/payment_request.avsc");
-        Schema createProductAvroSchema = loadSchemaFromClasspath("avro/create_product_request.avsc");
         Schema createMemberAvroSchema = loadSchemaFromClasspath("avro/create_member_request.avsc");
         Schema updateMemberAvroSchema = loadSchemaFromClasspath("avro/update_member_request.avsc");
+
+        Schema paymentRequestAvroSchema = loadSchemaFromClasspath("avro/payment_request.avsc");
+
+        Schema createProductAvroSchema = loadSchemaFromClasspath("avro/create_product_request.avsc");
+        Schema updateProductAvroSchema = loadSchemaFromClasspath("avro/create_product_request.avsc");
 
         // 스키마 추가
         mockSchemaRegistryClient.register("payment-request", paymentRequestAvroSchema);
         mockSchemaRegistryClient.register("create-product-request", createProductAvroSchema);
+        mockSchemaRegistryClient.register("update-product-request", updateProductAvroSchema);
         mockSchemaRegistryClient.register("create-member-request", createMemberAvroSchema);
         mockSchemaRegistryClient.register("update-member-request", updateMemberAvroSchema);
 

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -73,11 +73,13 @@ public class TestConfiguration {
         Schema paymentRequestAvroSchema = loadSchemaFromClasspath("avro/payment_request.avsc");
         Schema createProductAvroSchema = loadSchemaFromClasspath("avro/create_product_request.avsc");
         Schema createMemberAvroSchema = loadSchemaFromClasspath("avro/create_member_request.avsc");
+        Schema updateMemberAvroSchema = loadSchemaFromClasspath("avro/update_member_request.avsc");
 
         // 스키마 추가
         mockSchemaRegistryClient.register("payment-request", paymentRequestAvroSchema);
         mockSchemaRegistryClient.register("create-product-request", createProductAvroSchema);
         mockSchemaRegistryClient.register("create-member-request", createMemberAvroSchema);
+        mockSchemaRegistryClient.register("update-member-request", updateMemberAvroSchema);
 
         return mockSchemaRegistryClient;
     }

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -1,5 +1,7 @@
 package com.shoes.ordering.system;
 
+import com.shoes.ordering.system.domains.member.domain.application.ports.output.message.publisher.MemberCreatedRequestMessagePublisher;
+import com.shoes.ordering.system.domains.member.domain.application.ports.output.message.publisher.MemberUpdateRequestMessagePublisher;
 import com.shoes.ordering.system.domains.member.domain.application.ports.output.repository.MemberRepository;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCancelledPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCreatedPaymentRequestMessagePublisher;
@@ -28,6 +30,15 @@ public class TestConfiguration {
 
     @Bean
     public MemberRepository memberRepository() { return Mockito.mock(MemberRepository.class); }
+    @Bean
+    public MemberCreatedRequestMessagePublisher memberCreatedRequestMessagePublisher(){
+        return Mockito.mock(MemberCreatedRequestMessagePublisher.class);
+    }
+    @Bean
+    public MemberUpdateRequestMessagePublisher memberUpdateRequestMessagePublisher(){
+        return Mockito.mock(MemberUpdateRequestMessagePublisher.class);
+    }
+
     @Bean
     public ProductRepository productRepository() { return Mockito.mock(ProductRepository.class); }
     @Bean
@@ -61,10 +72,12 @@ public class TestConfiguration {
         // 스키마 생성
         Schema paymentRequestAvroSchema = loadSchemaFromClasspath("avro/payment_request.avsc");
         Schema createProductAvroSchema = loadSchemaFromClasspath("avro/create_product_request.avsc");
+        Schema createMemberAvroSchema = loadSchemaFromClasspath("avro/create_member_request.avsc");
 
         // 스키마 추가
         mockSchemaRegistryClient.register("payment-request", paymentRequestAvroSchema);
         mockSchemaRegistryClient.register("create-product-request", createProductAvroSchema);
+        mockSchemaRegistryClient.register("create-member-request", createMemberAvroSchema);
 
         return mockSchemaRegistryClient;
     }

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 import org.apache.avro.Schema;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
@@ -31,10 +32,12 @@ public class TestConfiguration {
     @Bean
     public MemberRepository memberRepository() { return Mockito.mock(MemberRepository.class); }
     @Bean
+    @Primary
     public MemberCreatedRequestMessagePublisher memberCreatedRequestMessagePublisher(){
         return Mockito.mock(MemberCreatedRequestMessagePublisher.class);
     }
     @Bean
+    @Primary
     public MemberUpdateRequestMessagePublisher memberUpdateRequestMessagePublisher(){
         return Mockito.mock(MemberUpdateRequestMessagePublisher.class);
     }

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberCreateCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberCreateCommandHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +32,7 @@ public class MemberCreateCommandHandlerTest {
     private MemberRepository memberRepository;
     @Autowired
     private MemberDataMapper memberDataMapper;
-    @Autowired
+    @MockBean
     private MemberCreatedRequestMessagePublisher memberCreatedRequestMessagePublisher;
 
     @Test
@@ -59,7 +60,7 @@ public class MemberCreateCommandHandlerTest {
         // then
         ArgumentCaptor<MemberCreatedEvent> capturedMemberCreatedEventCaptor
                 = ArgumentCaptor.forClass(MemberCreatedEvent.class);
-        verify(memberCreatedRequestMessagePublisher, atMost(2)).publish(capturedMemberCreatedEventCaptor.capture());
+        verify(memberCreatedRequestMessagePublisher).publish(capturedMemberCreatedEventCaptor.capture());
 
         MemberCreatedEvent capturedMemberCreatedEvent = capturedMemberCreatedEventCaptor.getValue();
         assertThat(capturedMemberCreatedEvent.getMember().getId().getValue())

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberCreateCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberCreateCommandHandlerTest.java
@@ -16,12 +16,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(classes = TestConfiguration.class)
 public class MemberCreateCommandHandlerTest {
@@ -60,7 +59,7 @@ public class MemberCreateCommandHandlerTest {
         // then
         ArgumentCaptor<MemberCreatedEvent> capturedMemberCreatedEventCaptor
                 = ArgumentCaptor.forClass(MemberCreatedEvent.class);
-        verify(memberCreatedRequestMessagePublisher).publish(capturedMemberCreatedEventCaptor.capture());
+        verify(memberCreatedRequestMessagePublisher, atMost(2)).publish(capturedMemberCreatedEventCaptor.capture());
 
         MemberCreatedEvent capturedMemberCreatedEvent = capturedMemberCreatedEventCaptor.getValue();
         assertThat(capturedMemberCreatedEvent.getMember().getId().getValue())

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberCreateCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberCreateCommandHandlerTest.java
@@ -32,7 +32,7 @@ public class MemberCreateCommandHandlerTest {
     private MemberRepository memberRepository;
     @Autowired
     private MemberDataMapper memberDataMapper;
-    @MockBean
+    @Autowired
     private MemberCreatedRequestMessagePublisher memberCreatedRequestMessagePublisher;
 
     @Test

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberUpdateCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberUpdateCommandHandlerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -33,7 +34,7 @@ public class MemberUpdateCommandHandlerTest {
     private MemberUpdateCommandHandler memberUpdateCommandHandler;
     @Autowired
     private MemberRepository memberRepository;
-    @Autowired
+    @MockBean
     private MemberUpdateRequestMessagePublisher memberUpdateRequestMessagePublisher;
 
     private Member member;
@@ -78,7 +79,7 @@ public class MemberUpdateCommandHandlerTest {
         // then
         ArgumentCaptor<MemberUpdatedEvent> capturedMemberUpdatedEventCaptor
                 = ArgumentCaptor.forClass(MemberUpdatedEvent.class);
-        verify(memberUpdateRequestMessagePublisher, atMost(2)).publish(capturedMemberUpdatedEventCaptor.capture());
+        verify(memberUpdateRequestMessagePublisher).publish(capturedMemberUpdatedEventCaptor.capture());
 
         MemberUpdatedEvent capturedMemberUpdatedEvent = capturedMemberUpdatedEventCaptor.getValue();
         assertThat(capturedMemberUpdatedEvent.getMember().getId().getValue())

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberUpdateCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberUpdateCommandHandlerTest.java
@@ -35,7 +35,7 @@ public class MemberUpdateCommandHandlerTest {
     private MemberUpdateCommandHandler memberUpdateCommandHandler;
     @Autowired
     private MemberRepository memberRepository;
-    @MockBean
+    @Autowired
     private MemberUpdateRequestMessagePublisher memberUpdateRequestMessagePublisher;
 
     private Member member;

--- a/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberUpdateCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/domain/application/handler/MemberUpdateCommandHandlerTest.java
@@ -17,15 +17,13 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(classes = TestConfiguration.class)
@@ -80,7 +78,7 @@ public class MemberUpdateCommandHandlerTest {
         // then
         ArgumentCaptor<MemberUpdatedEvent> capturedMemberUpdatedEventCaptor
                 = ArgumentCaptor.forClass(MemberUpdatedEvent.class);
-        verify(memberUpdateRequestMessagePublisher).publish(capturedMemberUpdatedEventCaptor.capture());
+        verify(memberUpdateRequestMessagePublisher, atMost(2)).publish(capturedMemberUpdatedEventCaptor.capture());
 
         MemberUpdatedEvent capturedMemberUpdatedEvent = capturedMemberUpdatedEventCaptor.getValue();
         assertThat(capturedMemberUpdatedEvent.getMember().getId().getValue())

--- a/src/test/java/com/shoes/ordering/system/domains/member/messaging/publisher/CreateMemberKafkaMessagePublisherTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/messaging/publisher/CreateMemberKafkaMessagePublisherTest.java
@@ -1,0 +1,88 @@
+package com.shoes.ordering.system.domains.member.messaging.publisher;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
+import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
+import com.shoes.ordering.system.common.kafka.model.CreateMemberRequestAvroModel;
+import com.shoes.ordering.system.domains.common.valueobject.StreetAddress;
+import com.shoes.ordering.system.domains.member.domain.core.entity.Member;
+import com.shoes.ordering.system.domains.member.domain.core.event.MemberCreatedEvent;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberKind;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@EmbeddedKafka(partitions = 1, topics = {"create-member-request"})
+@SpringBootTest(classes = TestConfiguration.class)
+@DirtiesContext
+class CreateMemberKafkaMessagePublisherTest {
+
+    @Autowired
+    private CreateMemberKafkaMessagePublisher createMemberKafkaMessagePublisher;
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired
+    private KafkaConfigData kafkaConfigData;
+    @Autowired
+    private KafkaConsumerConfigData kafkaConsumerConfigData;
+
+    @Test
+    @DisplayName("정상 publish 확인: MemberCreatedEvent 발행 확인")
+    void publishTest() {
+        // given
+        String targetTopic = "create-member-request";
+
+        Map<String, Object> consumerProps
+                = KafkaTestUtils.consumerProps("testMemberCreatedEventGroup", "false", embeddedKafkaBroker);
+
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
+        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+
+        // when
+        MemberCreatedEvent memberCreatedEvent = createMemberCreatedEvent();
+        createMemberKafkaMessagePublisher.publish(memberCreatedEvent);
+
+        // then
+        DefaultKafkaConsumerFactory<String, CreateMemberRequestAvroModel> consumerFactory
+                = new DefaultKafkaConsumerFactory<>(consumerProps);
+
+        Consumer<String, CreateMemberRequestAvroModel> consumer = consumerFactory.createConsumer();
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, targetTopic);
+        ConsumerRecord<String, CreateMemberRequestAvroModel> record
+                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, 1000L);
+
+        assertThat(record).isNotNull();
+        assertThat(record.topic()).isEqualTo(targetTopic);
+    }
+
+    private MemberCreatedEvent createMemberCreatedEvent() {
+        Member member =  Member.builder()
+                .memberKind(MemberKind.CUSTOMER)
+                .phoneNumber("0101231234")
+                .name("TestName")
+                .password("TestPassword123!@#")
+                .email("testEmail@test.com")
+                .address(new StreetAddress(UUID.randomUUID(),"123 Street", "99999", "City"))
+                .build();
+
+        member.initializeMember();
+
+        return new MemberCreatedEvent(member, ZonedDateTime.now());
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/member/messaging/publisher/UpdateMemberKafkaMessagePublisherTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/messaging/publisher/UpdateMemberKafkaMessagePublisherTest.java
@@ -1,0 +1,92 @@
+package com.shoes.ordering.system.domains.member.messaging.publisher;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
+import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
+import com.shoes.ordering.system.common.kafka.model.UpdateMemberRequestAvroModel;
+import com.shoes.ordering.system.domains.common.valueobject.StreetAddress;
+import com.shoes.ordering.system.domains.member.domain.core.entity.Member;
+import com.shoes.ordering.system.domains.member.domain.core.event.MemberUpdatedEvent;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberKind;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberStatus;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, topics = {"update-member-request"})
+@SpringBootTest(classes = TestConfiguration.class)
+class UpdateMemberKafkaMessagePublisherTest {
+
+    @Autowired
+    private UpdateMemberKafkaMessagePublisher updateMemberKafkaMessagePublisher;
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired
+    private KafkaConfigData kafkaConfigData;
+    @Autowired
+    private KafkaConsumerConfigData kafkaConsumerConfigData;
+
+    @Test
+    @DisplayName("정상 publish 확인: MemberUpdatedEvent 발행 확")
+    void publishTest() {
+        // given
+        String targetTopic = "update-member-request";
+
+        Map<String, Object> consumerProps
+                = KafkaTestUtils.consumerProps("testMemberUpdatedEventGroup", "false", embeddedKafkaBroker);
+
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
+        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+
+        // when
+        MemberUpdatedEvent memberUpdatedEvent = createMemberUpdatedEvent();
+        updateMemberKafkaMessagePublisher.publish(memberUpdatedEvent);
+
+        // then
+        DefaultKafkaConsumerFactory<String, UpdateMemberRequestAvroModel> consumerFactory
+                = new DefaultKafkaConsumerFactory<>(consumerProps);
+
+        Consumer<String, UpdateMemberRequestAvroModel> consumer = consumerFactory.createConsumer();
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, targetTopic);
+        ConsumerRecord<String, UpdateMemberRequestAvroModel> record
+                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, 1000L);
+
+        assertThat(record).isNotNull();
+        assertThat(record.topic()).isEqualTo(targetTopic);
+    }
+
+    private MemberUpdatedEvent createMemberUpdatedEvent() {
+        Member member =  Member.builder()
+                .memberId(new MemberId(UUID.randomUUID()))
+                .memberKind(MemberKind.CUSTOMER)
+                .memberStatus(MemberStatus.ACTIVATE)
+                .phoneNumber("0101231234")
+                .name("TestName")
+                .password("TestPassword123!@#")
+                .email("testEmail@test.com")
+                .address(new StreetAddress(UUID.randomUUID(),"123 Street", "99999", "City"))
+                .build();
+
+        return new MemberUpdatedEvent(member, ZonedDateTime.now());
+    }
+
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/messaging/publisher/CreateProductKafkaMessagePublisherTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/messaging/publisher/CreateProductKafkaMessagePublisherTest.java
@@ -1,0 +1,85 @@
+package com.shoes.ordering.system.domains.product.adapter.out.messaging.publisher;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
+import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
+import com.shoes.ordering.system.common.kafka.model.CreateProductRequestAvroModel;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductCreatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, topics = {"create-product-request"})
+@SpringBootTest(classes = TestConfiguration.class)
+class CreateProductKafkaMessagePublisherTest {
+    @Autowired
+    private CreateProductKafkaMessagePublisher createProductKafkaMessagePublisher;
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired
+    private KafkaConfigData kafkaConfigData;
+    @Autowired
+    private KafkaConsumerConfigData kafkaConsumerConfigData;
+
+    @Test
+    @DisplayName("정상 publish 확인: ProductCreatedEvent 발행 확인")
+    void publishTest() {
+        // given
+        String targetTopic = "create-product-request";
+
+        Map<String, Object> consumerProps
+                = KafkaTestUtils.consumerProps("testProductCreatedEventGroup", "false", embeddedKafkaBroker);
+
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
+        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+
+        // when
+        ProductCreatedEvent productCreatedEvent = createProductCreatedEvent();
+        createProductKafkaMessagePublisher.publish(productCreatedEvent);
+
+        // then
+        DefaultKafkaConsumerFactory<String, CreateProductRequestAvroModel> consumerFactory
+                = new DefaultKafkaConsumerFactory<>(consumerProps);
+
+        Consumer<String, CreateProductRequestAvroModel> consumer = consumerFactory.createConsumer();
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, targetTopic);
+        ConsumerRecord<String, CreateProductRequestAvroModel> record
+                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, 1000L);
+
+        assertThat(record).isNotNull();
+        assertThat(record.topic()).isEqualTo(targetTopic);
+    }
+
+    private ProductCreatedEvent createProductCreatedEvent() {
+        Product product = Product.builder()
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName1")
+                .description("Test Product1 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .build();
+
+        product.initializeProduct();
+
+        return new ProductCreatedEvent(product, ZonedDateTime.now());
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/messaging/publisher/UpdateProductKafkaMessagePublisherTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/messaging/publisher/UpdateProductKafkaMessagePublisherTest.java
@@ -1,0 +1,85 @@
+package com.shoes.ordering.system.domains.product.adapter.out.messaging.publisher;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
+import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
+import com.shoes.ordering.system.common.kafka.model.UpdateProductRequestAvroModel;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
+import com.shoes.ordering.system.domains.product.domain.core.event.ProductUpdatedEvent;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
+import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, topics = {"update-product-request"})
+@SpringBootTest(classes = TestConfiguration.class)
+class UpdateProductKafkaMessagePublisherTest {
+    @Autowired
+    private UpdateProductKafkaMessagePublisher updateProductKafkaMessagePublisher;
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired
+    private KafkaConfigData kafkaConfigData;
+    @Autowired
+    private KafkaConsumerConfigData kafkaConsumerConfigData;
+    @Test
+    @DisplayName("정상 publish 확인: ProductUpdatedEvent 발행 확")
+    void publishTest() {
+        // given
+        String targetTopic = "update-product-request";
+
+        Map<String, Object> consumerProps
+                = KafkaTestUtils.consumerProps("testProductUpdatedEventGroup", "false", embeddedKafkaBroker);
+
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
+        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+
+        // when
+        ProductUpdatedEvent productUpdatedEvent = createProductUpdatedEvent();
+        updateProductKafkaMessagePublisher.publish(productUpdatedEvent);
+
+        // then
+        DefaultKafkaConsumerFactory<String, UpdateProductRequestAvroModel> consumerFactory
+                = new DefaultKafkaConsumerFactory<>(consumerProps);
+
+        Consumer<String, UpdateProductRequestAvroModel> consumer = consumerFactory.createConsumer();
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, targetTopic);
+        ConsumerRecord<String, UpdateProductRequestAvroModel> record
+                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, 1000L);
+
+        assertThat(record).isNotNull();
+        assertThat(record.topic()).isEqualTo(targetTopic);
+    }
+
+    private ProductUpdatedEvent createProductUpdatedEvent() {
+        Product product = Product.builder()
+                .productId(new ProductId(UUID.randomUUID()))
+                .productCategory(ProductCategory.SHOES)
+                .name("TestProductName1")
+                .description("Test Product1 Description")
+                .price(new Money(new BigDecimal("200.00")))
+                .build();
+
+        return new ProductUpdatedEvent(product, ZonedDateTime.now());
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/CreateProductCommandHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/CreateProductCommandHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.math.BigDecimal;
 
@@ -32,7 +33,7 @@ public class CreateProductCommandHandlerTest {
     private ProductRepository productRepository;
     @Autowired
     private ProductDataMapper productDataMapper;
-    @Autowired
+    @MockBean
     private ProductCreatedRequestMessagePublisher productCreatedRequestMessagePublisher;
 
     @Test
@@ -56,7 +57,7 @@ public class CreateProductCommandHandlerTest {
         // then
         // 상호작용 확인
         ArgumentCaptor<ProductCreatedEvent> createdProductEventCaptor = ArgumentCaptor.forClass(ProductCreatedEvent.class);
-        verify(productCreatedRequestMessagePublisher, atMost(2)).publish(createdProductEventCaptor.capture());
+        verify(productCreatedRequestMessagePublisher).publish(createdProductEventCaptor.capture());
 
         ProductCreatedEvent capturedProductCreatedEvent = createdProductEventCaptor.getValue();
         assertThat(capturedProductCreatedEvent.getProduct().getId().getValue()).isEqualTo(resultCreateProductResponse.getProductId());


### PR DESCRIPTION
## 관련 이슈

[누락된 카프카 통합 테스트를 추가한다. #15](https://github.com/KEEMSY/shoes-ordering-system/issues/15)

## 변경사항
- 기존 테스트 내에서 사용되던 RequestMessagePublisher 설정 업데이트
  - @Primary 어노테이션 추가
- TestConfiguration 설정 변경
  -  Schema 등록 추가

<br>

## 체크리스트

> Member 관련 테스트 작성

- [x] CreateMemberKafkaMessagePublisher
- [x] UpdateMemberKafkaMessagePublisher

<br>

> Product 관련 테스트 작성

- [x] CreateProductKafkaMessagePublisher
- [x] UpdateProductKafkaMessagePublisher

<br>

> 기타

- [x] 토픽 정상 생성 확인 및 정상 소비 검증
- [x] RequestMessagePublisher 작성 시, 기존 작성된 테스트의 verify 검증 불안정성 원인 파악 및 해결
- [x] 전체 기존 테스트 정상 확인