### PR TITLE
Chore/kafka integration test-1 (누락된 카프카 통합 테스트를 추가한다.)

### DIFF
--- a/src/test/java/com/shoes/ordering/system/CustomKafkaTestConfig.java
+++ b/src/test/java/com/shoes/ordering/system/CustomKafkaTestConfig.java
@@ -1,0 +1,43 @@
+package com.shoes.ordering.system;
+
+import java.util.Map;
+
+import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
+import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
+import com.shoes.ordering.system.common.kafka.config.KafkaProducerConfigData;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomKafkaTestConfig {
+    @Autowired
+    private KafkaConfigData kafkaConfigData;
+    @Autowired
+    private KafkaConsumerConfigData kafkaConsumerConfigData;
+    @Autowired
+    private KafkaProducerConfigData kafkaProducerConfigData;
+
+    public Map<String, Object> createDefaultConsumerProps(EmbeddedKafkaBroker embeddedKafkaBroker) {
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafkaBroker);
+
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
+        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+
+        return consumerProps;
+    }
+
+    public Map<String, Object> createDefaultProducerProps(EmbeddedKafkaBroker embeddedKafkaBroker) {
+        Map<String, Object> producerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafkaBroker);
+
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProducerConfigData.getKeySerializerClass());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, kafkaProducerConfigData.getValueSerializerClass());
+        producerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+
+        return producerProps;
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/member/messaging/publisher/CreateMemberKafkaMessagePublisherTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/member/messaging/publisher/CreateMemberKafkaMessagePublisherTest.java
@@ -1,15 +1,13 @@
 package com.shoes.ordering.system.domains.member.messaging.publisher;
 
+import com.shoes.ordering.system.CustomKafkaTestConfig;
 import com.shoes.ordering.system.TestConfiguration;
-import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
-import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
 import com.shoes.ordering.system.common.kafka.model.CreateMemberRequestAvroModel;
 import com.shoes.ordering.system.domains.common.valueobject.StreetAddress;
 import com.shoes.ordering.system.domains.member.domain.core.entity.Member;
 import com.shoes.ordering.system.domains.member.domain.core.event.MemberCreatedEvent;
 import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberKind;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,35 +35,28 @@ class CreateMemberKafkaMessagePublisherTest {
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;
     @Autowired
-    private KafkaConfigData kafkaConfigData;
-    @Autowired
-    private KafkaConsumerConfigData kafkaConsumerConfigData;
+    private CustomKafkaTestConfig customKafkaTestConfig;
+    private Long TIMEOUT_LIMIT = 1000L;
 
     @Test
     @DisplayName("정상 publish 확인: MemberCreatedEvent 발행 확인")
     void publishTest() {
         // given
         String targetTopic = "create-member-request";
+        Map<String, Object> consumerProps = customKafkaTestConfig.createDefaultConsumerProps(embeddedKafkaBroker);
 
-        Map<String, Object> consumerProps
-                = KafkaTestUtils.consumerProps("testMemberCreatedEventGroup", "false", embeddedKafkaBroker);
-
-        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
-        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
-        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
-
+        DefaultKafkaConsumerFactory<String, CreateMemberRequestAvroModel> consumerFactory
+                = new DefaultKafkaConsumerFactory<>(consumerProps);
+        Consumer<String, CreateMemberRequestAvroModel> consumer = consumerFactory.createConsumer();
         // when
         MemberCreatedEvent memberCreatedEvent = createMemberCreatedEvent();
         createMemberKafkaMessagePublisher.publish(memberCreatedEvent);
 
         // then
-        DefaultKafkaConsumerFactory<String, CreateMemberRequestAvroModel> consumerFactory
-                = new DefaultKafkaConsumerFactory<>(consumerProps);
 
-        Consumer<String, CreateMemberRequestAvroModel> consumer = consumerFactory.createConsumer();
         embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, targetTopic);
         ConsumerRecord<String, CreateMemberRequestAvroModel> record
-                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, 1000L);
+                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, TIMEOUT_LIMIT);
 
         assertThat(record).isNotNull();
         assertThat(record.topic()).isEqualTo(targetTopic);

--- a/src/test/java/com/shoes/ordering/system/domains/order/adapter/out/messaging/publisher/CreateOrderKafkaMessagePublisherTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/order/adapter/out/messaging/publisher/CreateOrderKafkaMessagePublisherTest.java
@@ -1,9 +1,8 @@
 package com.shoes.ordering.system.domains.order.adapter.out.messaging.publisher;
 
+import com.shoes.ordering.system.CustomKafkaTestConfig;
 import com.shoes.ordering.system.common.kafka.model.PaymentRequestAvroModel;
 import com.shoes.ordering.system.TestConfiguration;
-import com.shoes.ordering.system.common.kafka.config.KafkaConfigData;
-import com.shoes.ordering.system.common.kafka.config.KafkaConsumerConfigData;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.common.valueobject.StreetAddress;
 import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
@@ -15,7 +14,6 @@ import com.shoes.ordering.system.domains.order.domain.core.valueobject.TrackingI
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductId;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,10 +46,9 @@ public class CreateOrderKafkaMessagePublisherTest {
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;
     @Autowired
-    private  KafkaConfigData kafkaConfigData;
-    @Autowired
-    private  KafkaConsumerConfigData kafkaConsumerConfigData;
+    private CustomKafkaTestConfig customKafkaTestConfig;
 
+    Long TIMEOUT_LIMIT = 1000L;
     private BigDecimal totalPrice = new BigDecimal("00.00");
     private int productQuantity = 1;
     private BigDecimal productPrice = new BigDecimal("50.00");
@@ -62,26 +59,22 @@ public class CreateOrderKafkaMessagePublisherTest {
     void publisherTest() {
         // given
         String targetTopic = "payment-request";
+        Map<String, Object> consumerProps = customKafkaTestConfig.createDefaultConsumerProps(embeddedKafkaBroker);
 
-        Map<String, Object> consumerProps
-                = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafkaBroker);
+        DefaultKafkaConsumerFactory<String, PaymentRequestAvroModel> consumerFactory
+                = new DefaultKafkaConsumerFactory<>(consumerProps);
 
-        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getKeyDeserializer());
-        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaConsumerConfigData.getValueDeserializer());
-        consumerProps.put(kafkaConfigData.getSchemaRegistryUrlKey(), kafkaConfigData.getSchemaRegistryUrl());
+        Consumer<String, PaymentRequestAvroModel> consumer = consumerFactory.createConsumer();
 
         // when
         OrderCreatedEvent orderCreatedEvent = createOrderCreatedEvent();
         createOrderKafkaMessagePublisher.publish(orderCreatedEvent);
 
         // then
-        DefaultKafkaConsumerFactory<String, PaymentRequestAvroModel> consumerFactory
-                = new DefaultKafkaConsumerFactory<>(consumerProps);
 
-        Consumer<String, PaymentRequestAvroModel> consumer = consumerFactory.createConsumer();
         embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, targetTopic);
         ConsumerRecord<String, PaymentRequestAvroModel> record
-                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, 2000L);
+                = KafkaTestUtils.getSingleRecord(consumer, targetTopic, TIMEOUT_LIMIT);
 
         assertThat(record).isNotNull();
         assertThat(record.topic()).isEqualTo(targetTopic);


### PR DESCRIPTION
## 관련 이슈 및 PR

- [누락된 카프카 통합 테스트를 추가한다. #15](https://github.com/KEEMSY/shoes-ordering-system/issues/15)
- [Chore/kafka integration test(누락된 카프카 통합 테스트를 추가한다.) #22](https://github.com/KEEMSY/shoes-ordering-system/pull/22)

<br>

## 변경 사항

> **지난 PR의 리뷰 사항**
<img width="905" alt="스크린샷 2023-09-01 오후 7 55 47" src="https://github.com/KEEMSY/shoes-ordering-system/assets/96563125/b8f6c3a8-9a0b-44f8-837f-ebad05bdf173">

<br>

[PR:Chore/kafka integration test(누락된 카프카 통합 테스트를 추가한다.](https://github.com/KEEMSY/shoes-ordering-system/pull/22) 의 리뷰 내용을 반영하여, 카프카 테스트 간 중복되는 설정 코드를 모듈화(Test Mother 처리)를 한다.

- CustomKafkaTestConfig 클래스를 통해, 테스트에서 사용되는 Default Consumer, Producer 설정코드 중복을 줄인다.

<br>

## 체크리스트

- [x] 중복되는 설정 및 가독성을 개선할 수 있는 설정 확인
- [x] 전체 기존 테스트 정상 확인