### PR TITLE
Feature/25 limit order per account(ProductRedisRepository 를 추가한다. #27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Install Docker
         run: |
           sudo apt-get update
-          sudo apt-get install -y docker.io
+          sudo apt-get remove containerd.io
+          sudo apt-get install docker.io
           sudo systemctl start docker
           sudo systemctl enable docker
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
 
 
     steps:
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo systemctl start docker
+          sudo systemctl enable docker
+
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'javax.validation:validation-api:2.0.1.Final'
 
+    runtimeOnly 'mysql:mysql-connector-java'
+
     // querydsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
@@ -55,11 +57,13 @@ dependencies {
 
     implementation("org.xerial.snappy:snappy-java:1.1.8.4")
 
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
-
-    runtimeOnly 'mysql:mysql-connector-java'
+    // forTest
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation "org.testcontainers:junit-jupiter:1.19.0"
+    testImplementation 'org.testcontainers:testcontainers:1.19.0'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation "org.testcontainers:junit-jupiter:1.19.0"
-    testImplementation 'org.testcontainers:testcontainers:1.19.0'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation "org.apache.avro:avro:1.11.0"
 
     def springKafkaVersion = '2.8.2'

--- a/src/main/java/com/shoes/ordering/system/common/redis/service/RedisService.java
+++ b/src/main/java/com/shoes/ordering/system/common/redis/service/RedisService.java
@@ -44,8 +44,8 @@ public class RedisService {
     }
 
     // set (opsForSet)
-    public void setSetOps(String key, String... values){
-        redisTemplate.opsForSet().add(key, values);
+    public Long setSetOps(String key, String... values){
+        return redisTemplate.opsForSet().add(key, values);
     }
 
     public Set<String> getSetOps(String key){

--- a/src/main/java/com/shoes/ordering/system/common/redis/service/RedisService.java
+++ b/src/main/java/com/shoes/ordering/system/common/redis/service/RedisService.java
@@ -1,0 +1,55 @@
+package com.shoes.ordering.system.common.redis.service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RedisService {
+    private final StringRedisTemplate redisTemplate;
+
+    @Autowired
+    public RedisService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // string (opsForValue)
+    public void setStringOps(String key, String value, long ttl, TimeUnit unit){
+        redisTemplate.opsForValue().set(key, value, ttl, unit);
+    }
+
+    public String getStringOps(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // list (opsForList)
+    public void setListOps(String key, List<String> values){
+        redisTemplate.opsForList().rightPushAll(key, values);
+    }
+
+    public List<String> getListOps(String key){
+        Long len = redisTemplate.opsForList().size(key);
+        return len == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, len-1);
+    }
+
+    // hash (opsForHash)
+    public void setHashOps(String key, HashMap<String, String> value){
+        redisTemplate.opsForHash().putAll(key, value);
+    }
+
+    public String getHashOps(String key, String hashKey){
+        return redisTemplate.opsForHash().hasKey(key, hashKey) ? (String) redisTemplate.opsForHash().get(key, hashKey) : new String();
+    }
+
+    // set (opsForSet)
+    public void setSetOps(String key, String... values){
+        redisTemplate.opsForSet().add(key, values);
+    }
+
+    public Set<String> getSetOps(String key){
+        return redisTemplate.opsForSet().members(key);
+    }
+
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/ProductAppliedRedisRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/ProductAppliedRedisRepository.java
@@ -1,0 +1,7 @@
+package com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository;
+
+import java.util.UUID;
+
+public interface ProductAppliedRedisRepository {
+    boolean addMemberIdToLimitedProduct(UUID productId, UUID memberId);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImpl.java
@@ -2,12 +2,14 @@ package com.shoes.ordering.system.domains.product.adapter.out.dataaccess.resposi
 
 import com.shoes.ordering.system.common.redis.service.RedisService;
 import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductAppliedRedisRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 
 @Repository
+@Slf4j
 public class ProductAppliedRedisRepositoryImpl implements ProductAppliedRedisRepository {
     private final RedisService redisService;
 
@@ -23,10 +25,12 @@ public class ProductAppliedRedisRepositoryImpl implements ProductAppliedRedisRep
         // Redis 집합에 memberId가 있는지 확인
         Long memberIdExists = redisService.setSetOps(productIdStr, memberIdStr);
         if (memberIdExists != 1) {
+            log.warn("memberId: {} is already registered in productId: {}", memberId, productId);
             return false;
         } else {
             // Redis 집합에 memberId 추가
             redisService.setSetOps(productIdStr, memberIdStr);
+            log.info("memberId: {} is registered in productId: {}", memberId, productId);
             return true;
         }
     }

--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImpl.java
@@ -20,13 +20,12 @@ public class ProductAppliedRedisRepositoryImpl implements ProductAppliedRedisRep
         String productIdStr = productId.toString();
         String memberIdStr = memberId.toString();
 
-        // Redis 집합에 userId가 있는지 확인
-        boolean memberIdExists = redisService.getSetOps(productIdStr).contains(memberIdStr);
-
-        if (memberIdExists) {
+        // Redis 집합에 memberId가 있는지 확인
+        Long memberIdExists = redisService.setSetOps(productIdStr, memberIdStr);
+        if (memberIdExists != 1) {
             return false;
         } else {
-            // Redis 집합에 UserId 추가
+            // Redis 집합에 memberId 추가
             redisService.setSetOps(productIdStr, memberIdStr);
             return true;
         }

--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.impl;
+
+import com.shoes.ordering.system.common.redis.service.RedisService;
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductAppliedRedisRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+
+@Repository
+public class ProductAppliedRedisRepositoryImpl implements ProductAppliedRedisRepository {
+    private final RedisService redisService;
+
+    public ProductAppliedRedisRepositoryImpl(RedisService redisService) {
+        this.redisService = redisService;
+    }
+
+    @Override
+    public boolean addMemberIdToLimitedProduct(UUID productId, UUID memberId) {
+        String productIdStr = productId.toString();
+        String memberIdStr = memberId.toString();
+
+        // Redis 집합에 userId가 있는지 확인
+        boolean memberIdExists = redisService.getSetOps(productIdStr).contains(memberIdStr);
+
+        if (memberIdExists) {
+            return false;
+        } else {
+            // Redis 집합에 UserId 추가
+            redisService.setSetOps(productIdStr, memberIdStr);
+            return true;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
     properties:
       hibernate.format_sql: true
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+  redis:
+    host: localhost
+    port: 6379
 
 member-service:
   create-member-request-topic-name: create-member-request

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -6,6 +6,7 @@ import com.shoes.ordering.system.domains.member.domain.application.ports.output.
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCancelledPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCreatedPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.repository.OrderRepository;
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductAppliedRedisRepository;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.message.publisher.ProductCreatedRequestMessagePublisher;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.message.publisher.ProductUpdatedRequestMessagePublisher;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.repository.ProductRepository;
@@ -44,6 +45,10 @@ public class TestConfiguration {
 
     @Bean
     public ProductRepository productRepository() { return Mockito.mock(ProductRepository.class); }
+    @Bean
+    public ProductAppliedRedisRepository productAppliedRedisRepository() {
+        return Mockito.mock(ProductAppliedRedisRepository.class);
+    }
     @Bean
     @Primary
     public ProductCreatedRequestMessagePublisher productCreatedRequestMessagePublisher() {

--- a/src/test/java/com/shoes/ordering/system/common/redis/service/RedisServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/common/redis/service/RedisServiceTest.java
@@ -1,0 +1,116 @@
+package com.shoes.ordering.system.common.redis.service;
+
+import com.shoes.ordering.system.TestConfiguration;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(classes = TestConfiguration.class)
+@Testcontainers
+public class RedisServiceTest {
+    private static final String REDIS_IMAGE = "redis:latest";
+    private static final int REDIS_PORT = 6379;
+    @Autowired
+    private RedisService redisService;
+
+
+    @Container
+    private static final GenericContainer<?> redisContainer =
+            new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
+                    .withExposedPorts(REDIS_PORT);
+
+    @BeforeAll
+    static void beforeAll() {
+        // Redis 컨테이너가 실행될 때 초기 설정이 필요한 경우 여기에서 설정 가능
+        System.setProperty("spring.redis.host", redisContainer.getHost());
+        System.setProperty("spring.redis.port", redisContainer.getFirstMappedPort().toString());
+    }
+
+    @Test
+    @DisplayName("setStringOps 성공 테스트: 문자열 저장")
+    public void setStringOpsTest() {
+        String key = "testKey";
+        String value = "testValue";
+        redisService.setStringOps(key, value, 1, TimeUnit.MINUTES);
+
+        String retrievedValue = redisService.getStringOps(key);
+
+        assertThat(value).isEqualTo(retrievedValue);
+    }
+    @Test
+    @DisplayName("getStringOps 테스트: 존재하지 않는 키로 조회하면 null 을 반환해야한다.")
+    public void getStringOpsFailureTest() {
+        String key = "nonExistentKey";
+        String retrievedValue = redisService.getStringOps(key);
+        assertThat(retrievedValue).isNull();
+    }
+
+
+    @Test
+    @DisplayName("setListOps 성공 테스트: 리스트 저장")
+    public void setListOpsTest() {
+        String key = "testList";
+        List<String> values = Arrays.asList("value1", "value2", "value3");
+        redisService.setListOps(key, values);
+
+        List<String> retrievedValues = redisService.getListOps(key);
+        assertThat(values).isEqualTo(retrievedValues);
+    }
+    @Test
+    @DisplayName("getListOps 테스트: 존재하지 않는 키로 조회하면 빈 리스트를 반환해야한다.")
+    public void getListOpsFailureTest() {
+        String key = "nonExistentList";
+        List<String> retrievedValues = redisService.getListOps(key);
+        assertThat(retrievedValues.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("setHashOps 성공 테스트: 해시맵 저장")
+    public void setHashOpsTest() {
+        String key = "testHash";
+        HashMap<String, String> values = new HashMap<>();
+        values.put("field1", "value1");
+        values.put("field2", "value2");
+
+        redisService.setHashOps(key, values);
+
+        String hashValue = redisService.getHashOps(key, "field1");
+        assertThat("value1").isEqualTo(hashValue);
+    }
+    @Test
+    @DisplayName("getHashOps 테스트: 존재하지 않는 키나 필드로 조회하면 빈 문자열을 반환해야 한다.")
+    public void getHashOpsTest() {
+        String key = "nonExistentHash";
+        String hashKey = "nonExistentField";
+        String hashValue = redisService.getHashOps(key, hashKey);
+        assertThat(hashValue).isEmpty();
+    }
+
+    @Test
+    @DisplayName("setSetOps 성공 테스트: 집합 저장")
+    public void setSetOpsTest() {
+        String key = "testSet";
+        String[] values = {"value1", "value2", "value3"};
+
+        redisService.setSetOps(key, values);
+
+        Set<String> retrievedValues = redisService.getSetOps(key);
+        assertThat(new HashSet<>(Arrays.asList(values))).isEqualTo(retrievedValues);
+    }
+    @Test
+    @DisplayName("getSetOps 테스트: 존재하지 않는 키로 조회하면 빈 집합을 반환해야 한다.")
+    public void getSetOpsTest() {
+        String key = "nonExistentSet";
+        Set<String> retrievedValues = redisService.getSetOps(key);
+        assertThat(retrievedValues.isEmpty()).isTrue();
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/common/redis/service/RedisServiceTest.java
+++ b/src/test/java/com/shoes/ordering/system/common/redis/service/RedisServiceTest.java
@@ -4,6 +4,7 @@ import com.shoes.ordering.system.TestConfiguration;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -15,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest(classes = TestConfiguration.class)
+@DirtiesContext
 @Testcontainers
 public class RedisServiceTest {
     private static final String REDIS_IMAGE = "redis:latest";

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImplTest.java
@@ -1,0 +1,73 @@
+package com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.impl;
+
+import com.shoes.ordering.system.TestConfiguration;
+import com.shoes.ordering.system.common.redis.service.RedisService;
+import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductAppliedRedisRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(classes = TestConfiguration.class)
+@DirtiesContext
+@Testcontainers
+class ProductAppliedRedisRepositoryImplTest {
+    private static final String REDIS_IMAGE = "redis:latest";
+    private static final int REDIS_PORT = 6379;
+    @Autowired
+    private RedisService redisService;
+    @Autowired
+    private ProductAppliedRedisRepository productAppliedRepository;
+
+    @Container
+    private static final GenericContainer<?> redisContainer =
+            new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
+                    .withExposedPorts(REDIS_PORT);
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("spring.redis.host", redisContainer.getHost());
+        System.setProperty("spring.redis.port", redisContainer.getFirstMappedPort().toString());
+    }
+
+    @Test
+    @DisplayName("addMemberIdToLimitedProduct 정상 확인: MemberId 정상 추가 확인")
+    public void addUserIdToProduct_SuccessTest() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // when
+        boolean result = productAppliedRepository.addMemberIdToLimitedProduct(productId, userId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("addMemberIdToLimitedProduct 에러 확인: 이미 MemberId 가 추가된 경우")
+    public void addUserIdToProduct_FailureTest() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String productIdStr = productId.toString();
+        String memberIdStr = userId.toString();
+        redisService.setSetOps(productIdStr, memberIdStr);
+
+        // when
+        boolean result = productAppliedRepository.addMemberIdToLimitedProduct(productId, userId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImplTest.java
@@ -8,8 +8,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -21,6 +26,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @SpringBootTest(classes = TestConfiguration.class)
 @DirtiesContext
 @Testcontainers
+@ContextConfiguration(initializers = ProductAppliedRedisRepositoryImplTest.ContainerPropertyInitializer.class)
 class ProductAppliedRedisRepositoryImplTest {
     private static final String REDIS_IMAGE = "redis:latest";
     private static final int REDIS_PORT = 6379;
@@ -32,7 +38,8 @@ class ProductAppliedRedisRepositoryImplTest {
     @Container
     private static final GenericContainer<?> redisContainer =
             new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
-                    .withExposedPorts(REDIS_PORT);
+                    .withExposedPorts(REDIS_PORT)
+                    .waitingFor(Wait.forListeningPort());
 
     @BeforeAll
     static void beforeAll() {
@@ -69,5 +76,13 @@ class ProductAppliedRedisRepositoryImplTest {
 
         // then
         assertThat(result).isFalse();
+    }
+    static class ContainerPropertyInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext context) {
+            TestPropertyValues.of("container.ports=" + redisContainer.getMappedPort(6379))
+                    .applyTo(context.getEnvironment());
+        }
     }
 }

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/respository/impl/ProductAppliedRedisRepositoryImplTest.java
@@ -2,7 +2,6 @@ package com.shoes.ordering.system.domains.product.adapter.out.dataaccess.resposi
 
 import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.common.redis.service.RedisService;
-import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductAppliedRedisRepository;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ class ProductAppliedRedisRepositoryImplTest {
     @Autowired
     private RedisService redisService;
     @Autowired
-    private ProductAppliedRedisRepository productAppliedRepository;
+    private ProductAppliedRedisRepositoryImpl productAppliedRepository;
 
     @Container
     private static final GenericContainer<?> redisContainer =

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,10 @@ spring:
       hibernate.format_sql: true
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
 
+  redis:
+    host: localhost
+    port: ${REDIS_PORT:16379}
+
 member-service:
   create-member-request-topic-name: create-member-request
   update-member-request-topic-name: update-member-request


### PR DESCRIPTION
## 관련 이슈
- #25
-  Closes #27 
 

<br>

## 변경 사항



> **build.gradle 설정 추가**

Redis 사용을 위한 종속성 추가 및 Redis 테스트를 위한 TestContainers 관련 종속성을 추가했습니다.

```java
// redis 관련
implementation 'org.springframework.boot:spring-boot-starter-data-redis'

// testcontainers 관련
testImplementation "org.testcontainers:junit-jupiter:1.19.0"
```

- Redis 통합테스트를 위한 다양한 방법(Local 환경구축, Embeded Redis 사용, TestContainers 사용)들이 존재했지만, 여러 요소를 고려하여 TestContainers 를 사용하기로 결정하였다.

<br>

> **application.yml 설정 추가**
- Redis 사용을 위한 설정 값 추가

<br>

> **CI 설정 추가**

- TestContainers 사용을 위한 Docker 설치 추가

<br>

> **ProductAppliedRedisRepository 추가**

- ProductAppliedRedisRepository 인터페이스 및 구현체 추가
- 동시성 테스트 진행

<br>

> **RedisService 추가**

- 다양한 Redis 자료구조에 대한 이해 및 추후 활용에 유용하게 사용하기 위해 추가
- 테스트 추가

<br>

## 체크리스트

- [x] application.yml 설정 값 확인
- [x] build.gradle 종속성 추가 확인
- [x] Redis 관련 테스트 진행(동시성 테스트 반드시 포함)
- [x] CI 파이프라인 정상작동 확인