### PR TITLE
Feature/41-1 product search(ProductRepository 의 명세에 대한 Product-Domain-Application 적용)

### DIFF
--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/adapter/ProductPersistenceAdapter.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/out/dataaccess/adapter/ProductPersistenceAdapter.java
@@ -53,7 +53,7 @@ public class ProductPersistenceAdapter implements ProductRepository {
     }
 
     @Override
-    public Optional<List<Product>> searchProductsByDynamicQuery(ProductSearchPersistenceRequest productSearchPersistenceRequest) {
-        return Optional.empty();
+    public List<Product> searchProductsByDynamicQuery(ProductSearchPersistenceRequest productSearchPersistenceRequest) {
+        return null;
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandler.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandler.java
@@ -42,7 +42,7 @@ public class TrackProductListQueryHandler {
 
     @Transactional
     public TrackProductListResponse searchProducts(DynamicSearchProductQuery searchProductQuery) {
-        Optional<List<Product>> resultProductList =
+        List<Product> resultProductList =
                 productRepository
                         .searchProductsByDynamicQuery(productDataMapper
                                 .dynamicSearchProductQueryToProductSearchPersistenceRequest(searchProductQuery));
@@ -50,6 +50,6 @@ public class TrackProductListQueryHandler {
             log.warn("Could not find any products");
             throw new ProductNotFoundException("Could not find any products");
         }
-        return productDataMapper.productListToTrackProductListResponse(resultProductList.get());
+        return productDataMapper.productListToTrackProductListResponse(resultProductList);
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/output/repository/ProductRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/domain/application/ports/output/repository/ProductRepository.java
@@ -16,5 +16,5 @@ public interface ProductRepository {
 
     Optional<Product> findByProductId(UUID productId);
     Optional<List<Product>> findByProductCategory(List<ProductCategory> productCategory);
-    Optional<List<Product>> searchProductsByDynamicQuery(ProductSearchPersistenceRequest productSearchPersistenceRequest);
+    List<Product> searchProductsByDynamicQuery(ProductSearchPersistenceRequest productSearchPersistenceRequest);
 }

--- a/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandlerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/domain/application/handler/TrackProductListQueryHandlerTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -72,7 +73,7 @@ public class TrackProductListQueryHandlerTest {
         productList = List.of(product1, product2);
 
         when(productRepository.findByProductCategory(validProductCategoryList)).thenReturn(Optional.of(productList));
-        when(productRepository.searchProductsByDynamicQuery(any(ProductSearchPersistenceRequest.class))).thenReturn(Optional.of(productList));
+        when(productRepository.searchProductsByDynamicQuery(any(ProductSearchPersistenceRequest.class))).thenReturn(productList);
     }
 
     @Test
@@ -125,7 +126,7 @@ public class TrackProductListQueryHandlerTest {
     public void searchProductErrorTest_NoProducts() {
         // given
         DynamicSearchProductQuery dynamicSearchProductQuery = DynamicSearchProductQuery.builder().build();
-        when(productRepository.searchProductsByDynamicQuery(any(ProductSearchPersistenceRequest.class))).thenReturn(Optional.empty());
+        when(productRepository.searchProductsByDynamicQuery(any(ProductSearchPersistenceRequest.class))).thenReturn(new ArrayList<>());
 
         // when, then
         assertThatThrownBy(()-> trackProductListQueryHandler.searchProducts(dynamicSearchProductQuery))


### PR DESCRIPTION
## 관련이슈

- #4 
- #41 
- #45 

<br>

## 변경사항

> **ProductRepository 의 명세 변경**

```java
// Optional 제거
List<Product> searchProductsByDynamicQuery(ProductSearchPersistenceRequest productSearchPersistenceRequest);
```

Product-Adapter 계층에서의 ProductRepository 구현 간, 이전 명세의 오류를 확인하고 수정된 내용을  Product-Domain-Application 에 반영하였습니다.

- `Optional` 은 `NullPointerException` 을 방지하고 값이 없을 때 명시적으로 처리하기 위해 사용하지만,  신규 유스케이스의 경우 값이 없을 경우 `빈 리스트` 를 반환(조회결과 없음)하므로 `Optional` 이 필요하지 않다.(항상 `isPresent 는 true` )

<br>

## 체크리스트

- [x] 기존 테스트 정상 확인
