### PR TITLE
Feature/52 product search(Product Web 계층 내, 다양한 Product 의 속성 값을 가지고 조회할 수 있는 유스케이스를 추가한다. #52)

### DIFF
--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/in/controller/rest/ProductQueryController.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/in/controller/rest/ProductQueryController.java
@@ -1,17 +1,13 @@
 package com.shoes.ordering.system.domains.product.adapter.in.controller.rest;
 
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.*;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
-import com.shoes.ordering.system.domains.product.domain.core.exception.ProductDomainException;
-import com.shoes.ordering.system.domains.product.domain.core.valueobject.ProductCategory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,6 +39,37 @@ public class ProductQueryController {
         TrackProductListResponse trackProductListResponse
                 = productQueryService.trackProductWithCategory(trackProductListQuery);
         log.info("Return product with ProductCategories: {}", trackProductListQuery.getProductCategoryList());
+        return ResponseEntity.ok(trackProductListResponse);
+    }
+
+    @GetMapping("/search/dynamic")
+    public ResponseEntity<TrackProductListResponse> searchProductsByDynamic(
+            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(name = "productCategoryList", required = false) List<String> productCategoryList,
+            @RequestParam(name = "minPrice", required = false) BigDecimal minPrice,
+            @RequestParam(name = "maxPrice", required = false) BigDecimal maxPrice
+    ) {
+        DynamicSearchProductQuery.Builder queryBuilder = DynamicSearchProductQuery.builder()
+                .name(name)
+                .productCategoryList(productCategoryList);
+
+        if (minPrice != null) {
+            queryBuilder.minPrice(new Money(minPrice));
+        }
+
+        if (maxPrice != null) {
+            queryBuilder.maxPrice(new Money(maxPrice));
+        }
+
+        DynamicSearchProductQuery dynamicSearchProductQuery = queryBuilder.build();
+        TrackProductListResponse trackProductListResponse
+                = productQueryService.searchProducts(dynamicSearchProductQuery);
+        log.info("Return product with Name: {}, ProductCategories: {}, minPrice: {}, maxPrice: {}"
+                ,dynamicSearchProductQuery.getName()
+                , dynamicSearchProductQuery.getProductCategoryList()
+                ,dynamicSearchProductQuery.getMinPrice()
+                , dynamicSearchProductQuery.getMaxPrice());
+
         return ResponseEntity.ok(trackProductListResponse);
     }
 }

--- a/src/main/java/com/shoes/ordering/system/domains/product/adapter/in/controller/rest/ProductQueryController.java
+++ b/src/main/java/com/shoes/ordering/system/domains/product/adapter/in/controller/rest/ProductQueryController.java
@@ -64,7 +64,7 @@ public class ProductQueryController {
         DynamicSearchProductQuery dynamicSearchProductQuery = queryBuilder.build();
         TrackProductListResponse trackProductListResponse
                 = productQueryService.searchProducts(dynamicSearchProductQuery);
-        log.info("Return product with Name: {}, ProductCategories: {}, minPrice: {}, maxPrice: {}"
+        log.info("Search products with Name: {}, ProductCategories: {}, minPrice: {}, maxPrice: {}"
                 ,dynamicSearchProductQuery.getName()
                 , dynamicSearchProductQuery.getProductCategoryList()
                 ,dynamicSearchProductQuery.getMinPrice()

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/in/controller/ProductQueryControllerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/in/controller/ProductQueryControllerTest.java
@@ -323,4 +323,21 @@ public class ProductQueryControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message")
                 .value("Invalid product categories: INVALID_CATEGORY"));
     }
+
+    @Test
+    @DisplayName("정상 searchProductsByDynamicErrorTest: Products 가 존재하지 않는 경우: 404 NotFound")
+    void searchProductsByDynamicErrorTest_ProductNotFoundException() throws Exception {
+        // given
+        String unknownProductName = "unknownProductName";
+        when(productQueryService.searchProducts(any(DynamicSearchProductQuery.class)))
+                .thenThrow(new ProductNotFoundException("Could not find any products"));
+
+        // when and then
+        mockMvc.perform(MockMvcRequestBuilders.get("/products/search/dynamic")
+                        .param("name", unknownProductName)
+                        .header("Content-Type", "application/json"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message")
+                .value("Could not find any products"));
+    }
 }

--- a/src/test/java/com/shoes/ordering/system/domains/product/adapter/in/controller/ProductQueryControllerTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/product/adapter/in/controller/ProductQueryControllerTest.java
@@ -2,10 +2,7 @@ package com.shoes.ordering.system.domains.product.adapter.in.controller;
 
 import com.shoes.ordering.system.TestConfiguration;
 import com.shoes.ordering.system.domains.common.valueobject.Money;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListQuery;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductListResponse;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductQuery;
-import com.shoes.ordering.system.domains.product.domain.application.dto.track.TrackProductResponse;
+import com.shoes.ordering.system.domains.product.domain.application.dto.track.*;
 import com.shoes.ordering.system.domains.product.domain.application.ports.input.service.ProductQueryService;
 import com.shoes.ordering.system.domains.product.domain.core.entity.Product;
 import com.shoes.ordering.system.domains.product.domain.core.exception.ProductNotFoundException;
@@ -170,5 +167,120 @@ public class ProductQueryControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message")
                         .value("Invalid product categories: " + invalidCategory));
 
+    }
+    @Test
+    @DisplayName("정상 searchProductsByDynamicDefaultTest:200")
+    void searchProductsByDynamicTest_Default() throws Exception {
+        // given
+
+        // Create sample products
+        ProductCategory category1 = ProductCategory.SHOES;
+        ProductCategory category2 = ProductCategory.CLOTHING;
+
+        Product product1 = Product.builder()
+                .productId(new ProductId((UUID.randomUUID())))
+                .name("Product 1")
+                .productCategory(category1)
+                .description("Description 1")
+                .price(new Money(BigDecimal.valueOf(100)))
+                .build();
+
+        Product product2 = Product.builder()
+                .productId(new ProductId((UUID.randomUUID())))
+                .name("Product 2")
+                .productCategory(category2)
+                .description("Description 2")
+                .price(new Money(BigDecimal.valueOf(200)))
+                .build();
+
+        List<Product> productList = Arrays.asList(product1, product2);
+
+        // Stub: productQueryService.searchProducts
+        TrackProductListResponse expectedResponse = TrackProductListResponse.builder()
+                .productList(productList)
+                .build();
+        when(productQueryService.searchProducts(any(DynamicSearchProductQuery.class))).thenReturn(expectedResponse);
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.get("/products/search/dynamic")
+                        .header("Content-Type", "application/json"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList", hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].name").value("Product 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].productCategory").value(category1.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].description").value("Description 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].price.amount").value(100))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].name").value("Product 2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].productCategory").value(category2.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].description").value("Description 2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].price.amount").value(200))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].price.greaterThanZero").value(true));
+    }
+    @Test
+    @DisplayName("정상 searchProductsByDynamicTest:200")
+    void searchProductsByDynamicTest() throws Exception {
+        // given
+
+        // Create sample products
+        ProductCategory category1 = ProductCategory.SHOES;
+        ProductCategory category2 = ProductCategory.CLOTHING;
+
+        Product product1 = Product.builder()
+                .productId(new ProductId((UUID.randomUUID())))
+                .name("Product 1")
+                .productCategory(category1)
+                .description("Description 1")
+                .price(new Money(BigDecimal.valueOf(100)))
+                .build();
+
+        Product product2 = Product.builder()
+                .productId(new ProductId((UUID.randomUUID())))
+                .name("Product 2")
+                .productCategory(category2)
+                .description("Description 2")
+                .price(new Money(BigDecimal.valueOf(200)))
+                .build();
+
+        List<Product> productList = Arrays.asList(product1, product2);
+
+        // Stub: productQueryService.searchProducts
+        TrackProductListResponse expectedResponse = TrackProductListResponse.builder()
+                .productList(productList)
+                .build();
+        when(productQueryService.searchProducts(any(DynamicSearchProductQuery.class))).thenReturn(expectedResponse);
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.get("/products/search/dynamic")
+                        .param("name", "Product")
+                        .param("productCategoryList", "SHOES,CLOTHING")
+                        .param("minPrice", "50.00")
+                        .param("maxPrice", "200.00")
+                        .header("Content-Type", "application/json"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList", hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].name").value("Product 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].productCategory").value(category1.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].description").value("Description 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[0].price.amount").value(100))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].name").value("Product 2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].productCategory").value(category2.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].description").value("Description 2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].price.amount").value(200))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.productList[1].price.greaterThanZero").value(true));
+    }
+
+    @Test
+    @DisplayName("정상 searchProductsByDynamicErrorTest: Input 값(Price)이 유효하지 않을 경우:400")
+    void searchProductsByDynamicErrorTest_InvalidPriceInput() throws Exception {
+        // given
+        BigDecimal invalidPrice = new BigDecimal("-100.00");
+
+        // when and then
+        mockMvc.perform(MockMvcRequestBuilders.get("/products/search/dynamic")
+                        .header("Content-Type", "application/json")
+                        .param("minPrice", String.valueOf(invalidPrice)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message")
+                        .value("The minPrice should be greater then Zero!"));
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #4 
- #52 

<br>

## 변경 사항

> **ProductQueryController 내 유스케이스 추가**

ProductQueryController 내 신규 유스케이스(다양한 Product 의 속성 값을 가지고 조회)를 추가하고 테스트를 진행했습니다. 

- ProductQueryControllerTest 내 테스트 및 애플리케이션 E2E 테스트 진행
  - 에러의 종류에 따라 올바른 에러 코드를 반환하는지 확인(`400`, `404`)
  - 입력 값이 없을 경우, default 값으로 검색이 되는지 확인
  - 입력 값이 있을 경우, 해당 조건에 알맞는 Products 검색 확인
  - 입력 값(Price, ProductCategory)이 올바르지 않을 경우, 에러확인
  - 조회되는 Products 가 없을 경우 에러 확인

<br>

URL을 통해 노출되는 쿼리 파라미터로 인해 발생할 수 있는 문제점은 DTO 자체의 입력 유효성 검사를 통해 방지 가능하다 판단하였습니다.

- DynamicSearchProductQuery 내 입력 유효성 검사 항목
  - `ProductCategory` 는 유효한 `ProductCategory` 만 조회 가능하다.
  - `minPrice`(최소 값) 은 `maxPrice`(최댓값)을 넘을 수 없다.
  - `name` 은 255의 길이를 넘길 수 없다.


<br>

## 체크리스트

- [x] 신규 기능 정상 작동 검증 및 전체 통합 테스트 정상 확인
- [x] Application 실행을 통한 E2E 테스트 진행