### PR TITLE
Feature/payment domain

### DIFF
--- a/src/main/java/com/shoes/ordering/system/domains/common/valueobject/PaymentOrderStatus.java
+++ b/src/main/java/com/shoes/ordering/system/domains/common/valueobject/PaymentOrderStatus.java
@@ -1,0 +1,5 @@
+package com.shoes.ordering.system.domains.common.valueobject;
+
+public enum PaymentOrderStatus {
+    PENDING, CANCELLED
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/PaymentRequestMessageListenerImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/PaymentRequestMessageListenerImpl.java
@@ -1,0 +1,60 @@
+package com.shoes.ordering.system.domains.payment.domain.application;
+
+import com.shoes.ordering.system.domains.payment.domain.application.dto.PaymentRequest;
+import com.shoes.ordering.system.domains.payment.domain.application.helper.PaymentRequestHelper;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.input.message.listener.PaymentRequestMessageListener;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher.PaymentCancelledMessagePublisher;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher.PaymentCompletedMessagePublisher;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher.PaymentFailedMessagePublisher;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentCancelledEvent;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentCompletedEvent;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentEvent;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentFailedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class PaymentRequestMessageListenerImpl implements PaymentRequestMessageListener {
+
+    private final PaymentRequestHelper paymentRequestHelper;
+    private final PaymentCompletedMessagePublisher paymentCompletedMessagePublisher;
+    private final PaymentCancelledMessagePublisher paymentCancelledMessagePublisher;
+    private final PaymentFailedMessagePublisher paymentFailedMessagePublisher;
+
+    public PaymentRequestMessageListenerImpl(PaymentRequestHelper paymentRequestHelper,
+                                             PaymentCompletedMessagePublisher paymentCompletedMessagePublisher,
+                                             PaymentCancelledMessagePublisher paymentCancelledMessagePublisher,
+                                             PaymentFailedMessagePublisher paymentFailedMessagePublisher) {
+        this.paymentRequestHelper = paymentRequestHelper;
+        this.paymentCompletedMessagePublisher = paymentCompletedMessagePublisher;
+        this.paymentCancelledMessagePublisher = paymentCancelledMessagePublisher;
+        this.paymentFailedMessagePublisher = paymentFailedMessagePublisher;
+    }
+
+    @Override
+    public void completePayment(PaymentRequest paymentRequest) {
+        PaymentEvent paymentEvent = paymentRequestHelper.persistPayment(paymentRequest);
+        fireEvent(paymentEvent);
+    }
+
+    @Override
+    public void cancelPayment(PaymentRequest paymentRequest) {
+        PaymentEvent paymentEvent = paymentRequestHelper.persisCancelPayment(paymentRequest);
+        fireEvent(paymentEvent);
+    }
+
+    private void fireEvent(PaymentEvent paymentEvent) {
+        log.info("Publishing payment event with paymentId: {} and orderId: {}",
+                paymentEvent.getPayment().getId().getValue(),
+                paymentEvent.getPayment().getOrderId().getValue());
+
+        if (paymentEvent instanceof PaymentCompletedEvent) {
+            paymentCompletedMessagePublisher.publish((PaymentCompletedEvent) paymentEvent);
+        } else if (paymentEvent instanceof PaymentCancelledEvent) {
+            paymentCancelledMessagePublisher.publish((PaymentCancelledEvent) paymentEvent);
+        } else if (paymentEvent instanceof PaymentFailedEvent) {
+            paymentFailedMessagePublisher.publish((PaymentFailedEvent) paymentEvent);
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/config/PaymentServiceConfigData.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/config/PaymentServiceConfigData.java
@@ -1,0 +1,13 @@
+package com.shoes.ordering.system.domains.payment.domain.application.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "payment-service")
+public class PaymentServiceConfigData {
+    private String paymentRequestTopicName;
+    private String paymentResponseTopicName;
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/dto/PaymentRequest.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/dto/PaymentRequest.java
@@ -1,0 +1,25 @@
+package com.shoes.ordering.system.domains.payment.domain.application.dto;
+
+import com.shoes.ordering.system.domains.common.valueobject.PaymentOrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PaymentRequest {
+    private String id;
+    private String orderId;
+    private String memberId;
+    private BigDecimal price;
+    private Instant createdAt;
+    private PaymentOrderStatus paymentOrderStatus;
+
+    public void setPaymentOrderStatus(PaymentOrderStatus paymentOrderStatus) {
+        this.paymentOrderStatus = paymentOrderStatus;
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/exception/PaymentApplicationServiceException.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/exception/PaymentApplicationServiceException.java
@@ -1,0 +1,13 @@
+package com.shoes.ordering.system.domains.payment.domain.application.exception;
+
+import com.shoes.ordering.system.domains.common.exception.DomainException;
+
+public class PaymentApplicationServiceException extends DomainException {
+    public PaymentApplicationServiceException(String message) {
+        super(message);
+    }
+
+    public PaymentApplicationServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/helper/PaymentRequestHelper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/helper/PaymentRequestHelper.java
@@ -1,0 +1,89 @@
+package com.shoes.ordering.system.domains.payment.domain.application.helper;
+
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.payment.domain.application.dto.PaymentRequest;
+import com.shoes.ordering.system.domains.payment.domain.application.exception.PaymentApplicationServiceException;
+import com.shoes.ordering.system.domains.payment.domain.application.mapper.PaymentDataMapper;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.CreditEntryRepository;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.CreditHistoryRepository;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.PaymentRepository;
+import com.shoes.ordering.system.domains.payment.domain.core.PaymentDomainService;
+import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditEntry;
+import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditHistory;
+import com.shoes.ordering.system.domains.payment.domain.core.entity.Payment;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class PaymentRequestHelper {
+
+    private final PaymentDomainService paymentDomainService;
+    private final PaymentDataMapper paymentDataMapper;
+    private final PaymentRepository paymentRepository;
+    private final CreditEntryRepository creditEntryRepository;
+    private final CreditHistoryRepository creditHistoryRepository;
+
+    public PaymentRequestHelper(PaymentDomainService paymentDomainService,
+                                PaymentDataMapper paymentDataMapper,
+                                PaymentRepository paymentRepository,
+                                CreditEntryRepository creditEntryRepository,
+                                CreditHistoryRepository creditHistoryRepository) {
+        this.paymentDomainService = paymentDomainService;
+        this.paymentDataMapper = paymentDataMapper;
+        this.paymentRepository = paymentRepository;
+        this.creditEntryRepository = creditEntryRepository;
+        this.creditHistoryRepository = creditHistoryRepository;
+    }
+
+    @Transactional
+    public PaymentEvent persistPayment(PaymentRequest paymentRequest) {
+        log.info("Received payment complete event for order id: {}", paymentRequest.getOrderId());
+        Payment payment = paymentDataMapper.paymentRequestToPayment(paymentRequest);
+        CreditEntry creditEntry = getCreditEntry(payment.getMemberId());
+        List<CreditHistory> creditHistories = getCreditHistory(payment.getMemberId());
+        List<String> failureMessages = new ArrayList<>();
+
+        PaymentEvent paymentEvent
+                = paymentDomainService.validateAndInitiatePayment(payment, creditEntry, creditHistories,failureMessages);
+        persisDBObjects(payment, creditEntry, creditHistories, failureMessages);
+        return paymentEvent;
+    }
+
+    private CreditEntry getCreditEntry(MemberId memberId) {
+        Optional<CreditEntry> creditEntry = creditEntryRepository.findByMemberId(memberId);
+        if (creditEntry.isEmpty()) {
+            log.error("Could not find credit for memberId: {}", memberId.getValue());
+            throw  new PaymentApplicationServiceException("Could not find credit for memberId: "
+            + memberId.getValue());
+        }
+        return creditEntry.get();
+    }
+
+    private List<CreditHistory> getCreditHistory(MemberId memberId) {
+        Optional<List<CreditHistory>> creditHistories = creditHistoryRepository.findByMemberId(memberId);
+        if (creditHistories.isEmpty()) {
+            log.error("Could not find credit history for memberId: {}", memberId.getValue());
+            throw new PaymentApplicationServiceException("Could not find credit history for memberId: "
+            + memberId.getValue());
+        }
+        return creditHistories.get();
+    }
+
+
+    private void persisDBObjects(Payment payment, CreditEntry creditEntry, List<CreditHistory> creditHistories, List<String> failureMessages) {
+        paymentRepository.save(payment);
+
+        if (failureMessages.isEmpty()) {
+            creditEntryRepository.save(creditEntry);
+            creditHistoryRepository.save(creditHistories.get(creditHistories.size() - 1));
+        }
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/mapper/PaymentDataMapper.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/mapper/PaymentDataMapper.java
@@ -1,0 +1,21 @@
+package com.shoes.ordering.system.domains.payment.domain.application.mapper;
+
+import com.shoes.ordering.system.domains.common.valueobject.Money;
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderId;
+import com.shoes.ordering.system.domains.payment.domain.application.dto.PaymentRequest;
+import com.shoes.ordering.system.domains.payment.domain.core.entity.Payment;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class PaymentDataMapper {
+    public Payment paymentRequestToPayment(PaymentRequest paymentRequest) {
+        return Payment.builder()
+                .memberId(new MemberId(UUID.fromString(paymentRequest.getMemberId())))
+                .orderId(new OrderId(UUID.fromString(paymentRequest.getOrderId())))
+                .price(new Money(paymentRequest.getPrice()))
+                .build();
+    }
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/input/message/listener/PaymentRequestMessageListener.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/input/message/listener/PaymentRequestMessageListener.java
@@ -1,0 +1,10 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.input.message.listener;
+
+import com.shoes.ordering.system.domains.payment.domain.application.dto.PaymentRequest;
+
+public interface PaymentRequestMessageListener {
+
+    void completePayment(PaymentRequest paymentRequest);
+
+    void cancelPayment(PaymentRequest paymentRequest);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCancelledMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCancelledMessagePublisher.java
@@ -2,6 +2,8 @@ package com.shoes.ordering.system.domains.payment.domain.application.ports.outpu
 
 import com.shoes.ordering.system.domains.common.event.publisher.DomainEventPublisher;
 import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentCancelledEvent;
+import org.springframework.stereotype.Component;
 
+@Component
 public interface PaymentCancelledMessagePublisher extends DomainEventPublisher<PaymentCancelledEvent> {
 }

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCancelledMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCancelledMessagePublisher.java
@@ -1,0 +1,7 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher;
+
+import com.shoes.ordering.system.domains.common.event.publisher.DomainEventPublisher;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentCancelledEvent;
+
+public interface PaymentCancelledMessagePublisher extends DomainEventPublisher<PaymentCancelledEvent> {
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCompletedMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCompletedMessagePublisher.java
@@ -2,6 +2,8 @@ package com.shoes.ordering.system.domains.payment.domain.application.ports.outpu
 
 import com.shoes.ordering.system.domains.common.event.publisher.DomainEventPublisher;
 import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentCompletedEvent;
+import org.springframework.stereotype.Component;
 
+@Component
 public interface PaymentCompletedMessagePublisher extends DomainEventPublisher<PaymentCompletedEvent> {
 }

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCompletedMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentCompletedMessagePublisher.java
@@ -1,0 +1,7 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher;
+
+import com.shoes.ordering.system.domains.common.event.publisher.DomainEventPublisher;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentCompletedEvent;
+
+public interface PaymentCompletedMessagePublisher extends DomainEventPublisher<PaymentCompletedEvent> {
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentFailedMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentFailedMessagePublisher.java
@@ -2,6 +2,8 @@ package com.shoes.ordering.system.domains.payment.domain.application.ports.outpu
 
 import com.shoes.ordering.system.domains.common.event.publisher.DomainEventPublisher;
 import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentFailedEvent;
+import org.springframework.stereotype.Component;
 
+@Component
 public interface PaymentFailedMessagePublisher extends DomainEventPublisher<PaymentFailedEvent> {
 }

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentFailedMessagePublisher.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/message/publisher/PaymentFailedMessagePublisher.java
@@ -1,0 +1,7 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher;
+
+import com.shoes.ordering.system.domains.common.event.publisher.DomainEventPublisher;
+import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentFailedEvent;
+
+public interface PaymentFailedMessagePublisher extends DomainEventPublisher<PaymentFailedEvent> {
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/CreditEntryRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/CreditEntryRepository.java
@@ -1,0 +1,15 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository;
+
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditEntry;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public interface CreditEntryRepository {
+
+    CreditEntry save(CreditEntry creditEntry);
+
+    Optional<CreditEntry> findByMemberId(MemberId memberId);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/CreditHistoryRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/CreditHistoryRepository.java
@@ -1,0 +1,16 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository;
+
+import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
+import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditHistory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public interface CreditHistoryRepository {
+
+    CreditHistory save(CreditHistory creditHistory);
+
+    Optional<List<CreditHistory>> findByMemberId(MemberId memberId);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/PaymentRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/PaymentRepository.java
@@ -1,0 +1,15 @@
+package com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository;
+
+import com.shoes.ordering.system.domains.payment.domain.core.entity.Payment;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public interface PaymentRepository {
+
+    Payment save(Payment payment);
+
+    Optional<Payment> findByOrderId(UUID orderId);
+}

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/PaymentRepository.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/application/ports/output/repository/PaymentRepository.java
@@ -1,15 +1,15 @@
 package com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository;
 
+import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderId;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.Payment;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Component
 public interface PaymentRepository {
 
     Payment save(Payment payment);
 
-    Optional<Payment> findByOrderId(UUID orderId);
+    Optional<Payment> findByOrderId(OrderId orderId);
 }

--- a/src/main/java/com/shoes/ordering/system/domains/payment/domain/core/PaymentDomainServiceImpl.java
+++ b/src/main/java/com/shoes/ordering/system/domains/payment/domain/core/PaymentDomainServiceImpl.java
@@ -1,8 +1,7 @@
-package com.shoes.ordering.system.domains.payment.domain;
+package com.shoes.ordering.system.domains.payment.domain.core;
 
 import com.shoes.ordering.system.domains.common.valueobject.Money;
 import com.shoes.ordering.system.domains.common.valueobject.PaymentStatus;
-import com.shoes.ordering.system.domains.payment.domain.core.PaymentDomainService;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditEntry;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditHistory;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.Payment;
@@ -13,6 +12,7 @@ import com.shoes.ordering.system.domains.payment.domain.core.event.PaymentFailed
 import com.shoes.ordering.system.domains.payment.domain.core.valueobject.CreditHistoryId;
 import com.shoes.ordering.system.domains.payment.domain.core.valueobject.TransactionType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -22,6 +22,7 @@ import java.util.UUID;
 import static com.shoes.ordering.system.domains.common.config.DomainConstants.UTC;
 
 @Slf4j
+@Component
 public class PaymentDomainServiceImpl implements PaymentDomainService {
     @Override
     public PaymentEvent validateAndInitiatePayment(Payment payment,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ order-service:
   payment-request-topic-name: payment-request
   payment-response-topic-name: payment-response
 
+payment-service:
+  payment-request-topic-name: payment-request
+  payment-response-topic-name: payment-response
+
 kafka-producer-config:
   key-serializer-class: org.apache.kafka.common.serialization.StringSerializer
   value-serializer-class: io.confluent.kafka.serializers.KafkaAvroSerializer

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,9 +67,9 @@ kafka-consumer-config:
 ---
 # Local Profile Configurations
 spring:
-  profiles:
-    active: local
-    on-profile: "local"
+  config:
+    activate:
+      on-profile: "local"
 
   datasource:
     url: jdbc:mysql://localhost:13306/shoes_ordering_system?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -6,6 +6,9 @@ import com.shoes.ordering.system.domains.member.domain.application.ports.output.
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCancelledPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCreatedPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.repository.OrderRepository;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.CreditEntryRepository;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.CreditHistoryRepository;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.PaymentRepository;
 import com.shoes.ordering.system.domains.product.adapter.out.dataaccess.respository.ProductAppliedRedisRepository;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.message.publisher.ProductCreatedRequestMessagePublisher;
 import com.shoes.ordering.system.domains.product.domain.application.ports.output.message.publisher.ProductUpdatedRequestMessagePublisher;
@@ -70,6 +73,19 @@ public class TestConfiguration {
     @Bean
     public OrderCancelledPaymentRequestMessagePublisher orderCancelledPaymentRequestMessagePublisher() {
         return Mockito.mock(OrderCancelledPaymentRequestMessagePublisher.class);
+    }
+
+    @Bean
+    public PaymentRepository paymentRepository() {
+        return Mockito.mock(PaymentRepository.class);
+    }
+    @Bean
+    public CreditEntryRepository creditEntryRepository() {
+        return Mockito.mock(CreditEntryRepository.class);
+    }
+    @Bean
+    public CreditHistoryRepository creditHistoryRepository() {
+        return Mockito.mock(CreditHistoryRepository.class);
     }
 
 

--- a/src/test/java/com/shoes/ordering/system/TestConfiguration.java
+++ b/src/test/java/com/shoes/ordering/system/TestConfiguration.java
@@ -6,6 +6,9 @@ import com.shoes.ordering.system.domains.member.domain.application.ports.output.
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCancelledPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.message.publisher.payment.OrderCreatedPaymentRequestMessagePublisher;
 import com.shoes.ordering.system.domains.order.domain.application.ports.output.repository.OrderRepository;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher.PaymentCancelledMessagePublisher;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher.PaymentCompletedMessagePublisher;
+import com.shoes.ordering.system.domains.payment.domain.application.ports.output.message.publisher.PaymentFailedMessagePublisher;
 import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.CreditEntryRepository;
 import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.CreditHistoryRepository;
 import com.shoes.ordering.system.domains.payment.domain.application.ports.output.repository.PaymentRepository;
@@ -86,6 +89,18 @@ public class TestConfiguration {
     @Bean
     public CreditHistoryRepository creditHistoryRepository() {
         return Mockito.mock(CreditHistoryRepository.class);
+    }
+    @Bean
+    public PaymentCompletedMessagePublisher paymentCompletedMessagePublisher() {
+        return Mockito.mock(PaymentCompletedMessagePublisher.class);
+    }
+    @Bean
+    public PaymentCancelledMessagePublisher paymentCancelledMessagePublisher() {
+        return Mockito.mock(PaymentCancelledMessagePublisher.class);
+    }
+    @Bean
+    public PaymentFailedMessagePublisher paymentFailedMessagePublisher() {
+        return Mockito.mock(PaymentFailedMessagePublisher.class);
     }
 
 

--- a/src/test/java/com/shoes/ordering/system/domains/payment/domain/PaymentServiceImplTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/payment/domain/PaymentServiceImplTest.java
@@ -5,6 +5,7 @@ import com.shoes.ordering.system.domains.common.valueobject.PaymentStatus;
 import com.shoes.ordering.system.domains.member.domain.core.valueobject.MemberId;
 import com.shoes.ordering.system.domains.order.domain.core.valueobject.OrderId;
 import com.shoes.ordering.system.domains.payment.domain.core.PaymentDomainService;
+import com.shoes.ordering.system.domains.payment.domain.core.PaymentDomainServiceImpl;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditEntry;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.CreditHistory;
 import com.shoes.ordering.system.domains.payment.domain.core.entity.Payment;

--- a/src/test/java/com/shoes/ordering/system/domains/payment/domain/application/helper/PaymentRequestHelperTest.java
+++ b/src/test/java/com/shoes/ordering/system/domains/payment/domain/application/helper/PaymentRequestHelperTest.java
@@ -70,7 +70,7 @@ class PaymentRequestHelperTest {
 
     @Test
     @DisplayName("정상 Payment 저장 확인: PaymentCompletedEvent 확인")
-    void persistPaymentTest() {
+    void persistPayment_CompletedOrderStatus_ShouldReturnCompletedEvent() {
         // given
         PaymentOrderStatus paymentOrderStatus = PaymentOrderStatus.PENDING;
         PaymentRequest paymentRequest = createPaymentRequest(stringMemberId, validPrice, paymentOrderStatus);
@@ -79,13 +79,12 @@ class PaymentRequestHelperTest {
         PaymentEvent expectedPaymentEvent = paymentRequestHelper.persistPayment(paymentRequest);
 
         // then
-        assertThat(expectedPaymentEvent).isNotNull();
-        assertThat(expectedPaymentEvent.getClass()).isEqualTo(PaymentCompletedEvent.class);
+        assertThat(expectedPaymentEvent).isNotNull().isInstanceOf(PaymentCompletedEvent.class);
     }
 
     @Test
     @DisplayName("정상 Payment 저장 에러 확인: CreditEntry 를 찾을 수 없을 경우")
-    void persistPaymentCreditEntryRepositoryErrorTest() {
+    void persistPayment_CreditEntryNotFound_ShouldThrowException() {
         // given
         given(creditEntryRepository.findByMemberId(any(MemberId.class)))
                 .willReturn(Optional.empty());
@@ -102,7 +101,7 @@ class PaymentRequestHelperTest {
 
     @Test
     @DisplayName("정상 Payment 저장 에러 확인: CreditHistories 를 찾을 수 없을 경우")
-    void persistPaymentCreditHistoryRepositoryErrorTest() {
+    void persistPayment_CreditHistoriesNotFound_ShouldThrowException() {
         // given
         given(creditHistoryRepository.findByMemberId(any(MemberId.class)))
                 .willReturn(Optional.empty());
@@ -119,7 +118,7 @@ class PaymentRequestHelperTest {
 
     @Test
     @DisplayName("정상 Payment 취소 저장 확인")
-    void persisCancelPaymentTest() {
+    void persisCancelPayment_ValidData_ShouldReturnCancelledEvent() {
         // given
         PaymentOrderStatus paymentOrderStatus = PaymentOrderStatus.CANCELLED;
         PaymentRequest paymentRequest = createPaymentRequest(stringMemberId, validPrice, paymentOrderStatus);
@@ -131,14 +130,13 @@ class PaymentRequestHelperTest {
         PaymentEvent expectedPaymentEvent = paymentRequestHelper.persisCancelPayment(paymentRequest);
 
         // then
-        assertThat(expectedPaymentEvent).isNotNull();
+        assertThat(expectedPaymentEvent).isNotNull().isInstanceOf(PaymentCancelledEvent.class);
         assertThat(expectedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELLED);
-        assertThat(expectedPaymentEvent.getClass()).isEqualTo(PaymentCancelledEvent.class);
     }
 
     @Test
     @DisplayName("정상 Payment 취소 간 저장 에러 확인: Payment 를 찾을 수 없을 경우")
-    void persisCancelPaymentErrorTest() {
+    void persisCancelPayment_PaymentNotFound_ShouldThrowException() {
         // given
         given(paymentRepository.findByOrderId(any(OrderId.class))).willReturn(Optional.empty());
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,7 +35,9 @@ order-service:
   payment-request-topic-name: payment-request
   payment-response-topic-name: payment-response
 
-
+payment-service:
+  payment-request-topic-name: payment-request
+  payment-response-topic-name: payment-response
 
 
 kafka-config:


### PR DESCRIPTION
## 작업 내용

`Payment-Domain-Application` 계층 개발

<br>

## 주요 기능

`Payment` 도메인 내 `유스케이스`를 구현하는데 필요한 `config`, `dto`, `exception`, `helper`, `mapper`, `ports` 를 추가했습니다.

- `config`: PaymentServiceConfigData
- `dto`: PaymentRequest
- `exception`: PaymentApplicationServiceException
- `helper`: PaymentRequestHelper
- `mapper`: PaymentDataMapper
- `ports`
  - `input`
    - `message.listener`: PaymentRequestMessageListener
  - `output`
    - `message.publisher`: PaymentCompletedMessagePublisher, PaymentCancelledMessagePublisher, PaymentFailedMessagePublisher
    - `repository`: PaymentRepository, CreditHistoryRepository, CreditEntryRepository  

<br>

`Payment-Domain-Application` 에서 사용되는 유스케이스는 `PaymentRequestMessageListener` 를 구현한 `PaymentRequestMessageListenerImpl` 클래스 내에 정의 되어 있습니다.

- `completePayment()`: PaymentRequest 에 따른 Payment 를 완료 및 저장, PaymentEvent 이벤트 발행
- `cancelPayment()`: PaymentRequest 에 따른 Payment 를 취소 및 저장, PaymentEvent 이벤트 발행

<br>

## 테스트

유스케이스는 `PaymentRequestMessageListenerImpl` 가 아닌 `PaymentRequestHelper` 위임하여 처리하므로 `PaymentRequestHelper` 를 테스트 진행하여 검증했습니다.

- 정상 Payment 저장 확인: PaymentCompletedEvent 확인
- 정상 Payment 저장 에러 확인: CreditEntry 를 찾을 수 없을 경우
- 정상 Payment 저장 에러 확인: CreditHistories 를 찾을 수 없을 경우
- 정상 Payment 취소 저장 확인
- 정상 Payment 취소 간 저장 에러 확인: Payment 를 찾을 수 없을 경우